### PR TITLE
Add colored tags feature

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -10,6 +10,7 @@ title: Developer Guide
 ## **Acknowledgements**
 
 * This project is based on the [AddressBook-Level3 project](https://github.com/se-edu/addressbook-level3) created by the [SE-EDU initiative](https://se-education.org).
+* `ColorUtil:isLightColor` is slightly adopted from the **StackOverflow** discussions [here](https://stackoverflow.com/a/14714716).
 * {list here sources of all reused/adapted ideas, code, documentation, and third-party libraries -- include links to the original source as well}
 
 --------------------------------------------------------------------------------------------------------------------

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -55,6 +55,8 @@ TutorSynch is a **desktop app for managing student contacts and academic details
 * Items with `…`​ after them can be used multiple times including zero times.<br>
   e.g. `[t/TAG]…​` can be used as ` ` (i.e. 0 times), `t/cs4238`, `t/cs2103 t/GEA1000` etc.
 
+* Any tags can be written as an alphanumeric tag, accompanied by `#` followed by 6 hexadecimal color code. (E.g. `CS2040C#ED9E49`)
+
 * Parameters can be in any order.<br>
   e.g. if the command specifies `n/NAME p/PHONE_NUMBER`, `p/PHONE_NUMBER n/NAME` is also acceptable.
 

--- a/docs/team/benny.md
+++ b/docs/team/benny.md
@@ -10,6 +10,8 @@ Given below are my contributions to the project.
 * **New Feature**: Added the ability to record a student's payment information. [\#59](https://github.com/AY2425S2-CS2103-F15-2/tp/pull/59)
   * What it does: Allows the user to record the Tutoring Fee and Payment Date of a student.
   * Highlights: This command is carefully setup in a way that allows for future enhancement (such as using Payment Date to indicate late payment, early payment, or due soon). This requires carefully thought out OOP design principles.
+* **New Feature**: Added the ability to use custom color code for Tags. [\#73](https://github.com/AY2425S2-CS2103-F15-2/tp/pull/73)
+  * Highlights: Contains a Tooltip such that, when hovering over a tag, shows the Hex Color Code of the tag.
 
 * **Documentation**:
   * Ui Mockup:
@@ -20,6 +22,9 @@ Given below are my contributions to the project.
   * Developer Guide:
     * Modified existing use cases for `UC01 - Add a new student`, `UC03 - Delete a student`, and `UC04 - List all students`. [\#46](https://github.com/AY2425S2-CS2103-F15-2/tp/pull/46)
     * Added use cases for `UC02 - Edit a student's information`, `UC05 - Record payment information for existing student`, `UC06 - Bulk delete student records`, `UC07 - Compare progress between two students`. [\#46](https://github.com/AY2425S2-CS2103-F15-2/tp/pull/46)
+
+* **Community**:
+  * PRs reviewed (with non-trivial review comments): [\#58](https://github.com/AY2425S2-CS2103-F15-2/tp/pull/58#pullrequestreview-2686240341)
 
 <!--
 * **New Feature**: Added the ability to undo/redo previous commands.

--- a/src/main/java/seedu/address/commons/util/ColorUtil.java
+++ b/src/main/java/seedu/address/commons/util/ColorUtil.java
@@ -12,6 +12,8 @@ public class ColorUtil {
      * @return true if the color is light, false if dark.
      */
     public static boolean isLightColor(String hexColor) {
+        // [ACKNOWLEDGEMENT] Code logic adopted from here:
+        // https://stackoverflow.com/a/14714716
         try {
             Color color = Color.decode("#" + hexColor);
 

--- a/src/main/java/seedu/address/commons/util/ColorUtil.java
+++ b/src/main/java/seedu/address/commons/util/ColorUtil.java
@@ -1,0 +1,28 @@
+package seedu.address.commons.util;
+
+import java.awt.Color;
+
+/**
+ * Helper functions for handling color.
+ */
+public class ColorUtil {
+    /**
+     * Determines if a hex color is light or dark.
+     * @param hexColor The 6-character hex code (e.g., "F3B7D2").
+     * @return true if the color is light, false if dark.
+     */
+    public static boolean isLightColor(String hexColor) {
+        try {
+            Color color = Color.decode("#" + hexColor);
+
+            // Calculate luminance (perceived brightness)
+            double luminance = (0.299 * color.getRed()
+                    + 0.587 * color.getGreen()
+                    + 0.114 * color.getBlue()) / 255;
+
+            return luminance > 0.5; // Light if luminance > 0.5, otherwise dark
+        } catch (Exception e) {
+            return true; // Default to light to prevent errors
+        }
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -107,7 +107,7 @@ public class ParserUtil {
     public static Tag parseTag(String tag) throws ParseException {
         requireNonNull(tag);
         String trimmedTag = tag.trim();
-        if (!Tag.isValidTagName(trimmedTag)) {
+        if (!Tag.isValidTag(trimmedTag)) {
             throw new ParseException(Tag.MESSAGE_CONSTRAINTS);
         }
         return new Tag(trimmedTag);

--- a/src/main/java/seedu/address/model/tag/Tag.java
+++ b/src/main/java/seedu/address/model/tag/Tag.java
@@ -5,30 +5,31 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
 
 /**
  * Represents a Tag in the address book.
- * Guarantees: immutable; name is valid as declared in {@link #isValidTagName(String)}
+ * Guarantees: immutable; name is valid as declared in {@link #isValidTag(String)}
  */
 public class Tag {
 
-    public static final String MESSAGE_CONSTRAINTS = "Tags names should be alphanumeric";
-    public static final String VALIDATION_REGEX = "\\p{Alnum}+";
+    public static final String MESSAGE_CONSTRAINTS = "Tags names should be alphanumeric, while its color codes should"
+            + "be 6 hexadecimal long (e.g. \"CS2040C#F2552E\")";
+    public static final String VALIDATION_REGEX = "^(\\p{Alnum}+)(?:#([A-Fa-f0-9]{6}))?$";
 
-    public final String tagName;
+    public final String fullTag;
 
     /**
      * Constructs a {@code Tag}.
      *
-     * @param tagName A valid tag name.
+     * @param fullTag A valid full tag (e.g. `CS2040C#F2552E`).
      */
-    public Tag(String tagName) {
-        requireNonNull(tagName);
-        checkArgument(isValidTagName(tagName), MESSAGE_CONSTRAINTS);
-        this.tagName = tagName;
+    public Tag(String fullTag) {
+        requireNonNull(fullTag);
+        checkArgument(isValidTag(fullTag), MESSAGE_CONSTRAINTS);
+        this.fullTag = fullTag;
     }
 
     /**
-     * Returns true if a given string is a valid tag name.
+     * Returns true if a given string is a valid tag format.
      */
-    public static boolean isValidTagName(String test) {
+    public static boolean isValidTag(String test) {
         return test.matches(VALIDATION_REGEX);
     }
 
@@ -44,19 +45,20 @@ public class Tag {
         }
 
         Tag otherTag = (Tag) other;
-        return tagName.equals(otherTag.tagName);
+        // Tag is the same as long as the `tagName` (First half) is the same. `hexColor` (Second half) is ignored here.
+        return fullTag.split("#")[0].equals(otherTag.fullTag.split("#")[0]);
     }
 
     @Override
     public int hashCode() {
-        return tagName.hashCode();
+        return fullTag.hashCode();
     }
 
     /**
      * Format state as text for viewing.
      */
     public String toString() {
-        return '[' + tagName + ']';
+        return '[' + fullTag + ']';
     }
 
 }

--- a/src/main/java/seedu/address/storage/JsonAdaptedTag.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedTag.java
@@ -11,26 +11,26 @@ import seedu.address.model.tag.Tag;
  */
 class JsonAdaptedTag {
 
-    private final String tagName;
+    private final String fullTag;
 
     /**
-     * Constructs a {@code JsonAdaptedTag} with the given {@code tagName}.
+     * Constructs a {@code JsonAdaptedTag} with the given {@code fullTag}.
      */
     @JsonCreator
-    public JsonAdaptedTag(String tagName) {
-        this.tagName = tagName;
+    public JsonAdaptedTag(String fullTag) {
+        this.fullTag = fullTag;
     }
 
     /**
      * Converts a given {@code Tag} into this class for Jackson use.
      */
     public JsonAdaptedTag(Tag source) {
-        tagName = source.tagName;
+        fullTag = source.fullTag;
     }
 
     @JsonValue
-    public String getTagName() {
-        return tagName;
+    public String getFullTag() {
+        return fullTag;
     }
 
     /**
@@ -39,10 +39,10 @@ class JsonAdaptedTag {
      * @throws IllegalValueException if there were any data constraints violated in the adapted tag.
      */
     public Tag toModelType() throws IllegalValueException {
-        if (!Tag.isValidTagName(tagName)) {
+        if (!Tag.isValidTag(fullTag)) {
             throw new IllegalValueException(Tag.MESSAGE_CONSTRAINTS);
         }
-        return new Tag(tagName);
+        return new Tag(fullTag);
     }
 
 }

--- a/src/main/java/seedu/address/ui/PersonCard.java
+++ b/src/main/java/seedu/address/ui/PersonCard.java
@@ -93,6 +93,11 @@ public class PersonCard extends UiPart<Region> {
                 .forEach(tag -> tags.getChildren().add(createTagLabel(tag)));
     }
 
+    /**
+     * A helper function to create a {@code Label} given a {@code Tag}.
+     * @param tag A valid Tag object.
+     * @return The corresponding JavaFX Label object.
+     */
     private Label createTagLabel(Tag tag) {
         String[] parts = tag.fullTag.split("#");
         Label label = new Label(parts[0]);

--- a/src/main/java/seedu/address/ui/PersonCard.java
+++ b/src/main/java/seedu/address/ui/PersonCard.java
@@ -4,11 +4,15 @@ import java.util.Comparator;
 
 import javafx.fxml.FXML;
 import javafx.scene.control.Label;
+import javafx.scene.control.Tooltip;
 import javafx.scene.layout.FlowPane;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Region;
+import javafx.util.Duration;
+import seedu.address.commons.util.ColorUtil;
 import seedu.address.model.person.PaymentInfo;
 import seedu.address.model.person.Person;
+import seedu.address.model.tag.Tag;
 
 /**
  * An UI component that displays information of a {@code Person}.
@@ -85,7 +89,29 @@ public class PersonCard extends UiPart<Region> {
         }
 
         person.getTags().stream()
-                .sorted(Comparator.comparing(tag -> tag.tagName))
-                .forEach(tag -> tags.getChildren().add(new Label(tag.tagName)));
+                .sorted(Comparator.comparing(tag -> tag.fullTag))
+                .forEach(tag -> tags.getChildren().add(createTagLabel(tag)));
+    }
+
+    private Label createTagLabel(Tag tag) {
+        String[] parts = tag.fullTag.split("#");
+        Label label = new Label(parts[0]);
+        if (parts.length == 2 && !parts[1].isEmpty()) {
+            // Determine text and background color if custom color code is found...
+            String hexColor = parts[1];
+            String textColor = ColorUtil.isLightColor(hexColor) ? "black" : "white";
+            label.setStyle("-fx-background-color: #" + hexColor + "; -fx-text-fill: " + textColor + ";");
+            // Create a tooltip showing the hex color
+            Tooltip tooltip = new Tooltip("Color: #" + hexColor);
+            tooltip.setShowDelay(Duration.millis(0)); // No delay before showing
+            Tooltip.install(label, tooltip); // Attach tooltip to the label
+        } else {
+            // Create a tooltip showing the hex color
+            Tooltip tooltip = new Tooltip("Color: #3e7b91");
+            tooltip.setShowDelay(Duration.millis(0)); // No delay before showing
+            Tooltip.install(label, tooltip); // Attach tooltip to the label
+        }
+
+        return label;
     }
 }

--- a/src/test/java/seedu/address/commons/util/ColorUtilTest.java
+++ b/src/test/java/seedu/address/commons/util/ColorUtilTest.java
@@ -1,0 +1,24 @@
+package seedu.address.commons.util;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.commons.util.ColorUtil.isLightColor;
+
+import org.junit.jupiter.api.Test;
+
+public class ColorUtilTest {
+    @Test
+    public void isLightColor_whiteHexCode_returnTrue() {
+        assertTrue(isLightColor("FFFFFF"));
+    }
+
+    @Test
+    public void isLightColor_blackHexCode_returnFalse() {
+        assertFalse(isLightColor("000000"));
+    }
+
+    @Test
+    public void isLightColor_invalidHexCode_returnTrue() {
+        assertTrue(isLightColor("INVALID_HEX_COLOR"));
+    }
+}

--- a/src/test/java/seedu/address/model/tag/TagTest.java
+++ b/src/test/java/seedu/address/model/tag/TagTest.java
@@ -20,7 +20,7 @@ public class TagTest {
     @Test
     public void isValidTagName() {
         // null tag name
-        assertThrows(NullPointerException.class, () -> Tag.isValidTagName(null));
+        assertThrows(NullPointerException.class, () -> Tag.isValidTag(null));
     }
 
 }

--- a/src/test/java/seedu/address/testutil/PersonUtil.java
+++ b/src/test/java/seedu/address/testutil/PersonUtil.java
@@ -36,7 +36,7 @@ public class PersonUtil {
         sb.append(PREFIX_EMAIL + person.getEmail().value + " ");
         sb.append(PREFIX_ADDRESS + person.getAddress().value + " ");
         person.getTags().stream().forEach(
-            s -> sb.append(PREFIX_TAG + s.tagName + " ")
+            s -> sb.append(PREFIX_TAG + s.fullTag + " ")
         );
         sb.append(PREFIX_CURRENT_GRADE + person.getCurrentGrade().value + " ");
         return sb.toString();
@@ -58,7 +58,7 @@ public class PersonUtil {
             if (tags.isEmpty()) {
                 sb.append(PREFIX_TAG);
             } else {
-                tags.forEach(s -> sb.append(PREFIX_TAG).append(s.tagName).append(" "));
+                tags.forEach(s -> sb.append(PREFIX_TAG).append(s.fullTag).append(" "));
             }
         }
         return sb.toString();


### PR DESCRIPTION
Closes #62 

## Notes:
- Changes are kept to a minimal.
- Tags now include possible custom color and default color.
- Test cases included for `ColorUtil.java`.
- Added Tooltips that display the Color Hex Code when hovering over the tags.
- Persistent Storage for Colored Tags.
- Updated User Guide.

![image](https://github.com/user-attachments/assets/cc436f5d-5dcc-46af-bfaf-51e7dd048e28)
![image](https://github.com/user-attachments/assets/afd9a35a-a30d-44d9-b101-78e5440c7fe8)
![image](https://github.com/user-attachments/assets/14328d3d-3ce0-44a1-9a8b-6a4145296e10)
![image](https://github.com/user-attachments/assets/7436ae15-7672-4245-990f-e2c488e7fdb2)
