### PR TITLE
Add functionality for t+/ appending tags

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -110,16 +110,19 @@ Examples:
 *  `edit 1 p/91234567 e/johndoe@example.com` Edits the phone number and email address of the 1st person to be `91234567` and `johndoe@example.com` respectively.
 
 
-#### Tag Editing : `t/`, `t-/`
-* When editing tags, any number of `t/` or `t-/` may be provided, order of execution is as follows: 
+#### Tag Editing : `t/`, `t-/`, `t+/`
+* When editing tags, any number of `t/`, `t-/` or `t+/` may be provided, order of execution is as follows:
 1. Tags prefixed with `t/` form the new list of tags (overwriting the old tags), if none are provided, old list of tags is used for the next steps.
 2. Tags prefixed with `t-/` are removed from the list provided by the last step. If the tag to be removed does not exist, the app silently continues with the rest.
-3. The final tag list is updated to the person.
+3. Tags prefixed with `t+/` are added to the current list. If the tag already exists, the final list remains unchanged as tags are unique.
+4. The final tag list is updated to the person.
 
 Examples:
 *  `edit 2 n/Betsy Crower t/` Edits the name of the 2nd person to be `Betsy Crower` and clears all existing tags.
 *  `edit 2 t-/Maths` Edits the tags of the 2nd person by removing `Maths` from existing list of tags.
 *  `edit 1 t/Maths t/Science t-/Science ` Edits the tags of the 2nd person by clearing all existing tags and adding `Maths`.
+*  `edit 1 t+/friend t+/owesMoney` appends friend and owesMoney to existing tags (without overwriting or removing).
+
 
 ### Updating a person's payment information : `payment`
 
@@ -214,14 +217,14 @@ _Details coming soon ..._
 
 ## Command summary
 
-| Action     | Format, Examples                                                                                                                                                                                                  |
-|------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| **Add**    | `add n/NAME p/PHONE_NUMBER e/EMAIL a/ADDRESS [cy/CURRENT_YEAR] [cg/CURRENT_GRADE] [t/TAG]…​` <br> e.g., `add n/James Ho p/22224444 e/jamesho@example.com a/123, Clementi Rd, 1234665 cg/D t/friend t/colleague`|
-| **Clear**  | `clear`                                                                                                                                                                                                           |
-| **Delete** | `delete INDEX`<br> e.g., `delete 3`                                                                                                                                                                               |
-| **Edit**   | `edit INDEX [n/NAME] [p/PHONE_NUMBER] [e/EMAIL] [a/ADDRESS] [cy/CURRENT_YEAR] [cg/CURRENT_GRADE] [t/TAG]… [t-/TAGS_TO_REMOVE]…​`<br> e.g.,`edit 2 n/James Lee e/jameslee@example.com`                                               |
-| **Payment**| `payment INDEX [f/FEE] d/[PAYMENT_DATE]`<br> e.g., `payment 4 f/1000 d/14-11-2000`                                                                                                                                |
-| **Find**   | `find KEYWORD [MORE_KEYWORDS]`<br> e.g., `find James Jake`                                                                                                                                                        |
-| **List**   | `list`                                                                                                                                                                                                            |
-| **Help**   | `help`                                                                                                                                                                                                            |
+| Action     | Format, Examples                                                                                                                                                                                                                    |
+|------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **Add**    | `add n/NAME p/PHONE_NUMBER e/EMAIL a/ADDRESS [l/ EDUCATION_LEVEL] [cy/CURRENT_YEAR] [cg/CURRENT_GRADE] [t/TAG]…​` <br> e.g., `add n/James Ho p/22224444 e/jamesho@example.com a/123, Clementi Rd, 1234665 cg/D t/friend t/colleague` |
+| **Clear**  | `clear`                                                                                                                                                                                                                             |
+| **Delete** | `delete INDEX`<br> e.g., `delete 3`                                                                                                                                                                                                 |
+| **Edit**   | `edit INDEX [n/NAME] [p/PHONE_NUMBER] [e/EMAIL] [a/ADDRESS] [cy/CURRENT_YEAR] [cg/CURRENT_GRADE] [t/TAG]… [t-/TAGS_TO_REMOVE][t+/TAGS_TO_APPEND]…​`<br> e.g.,`edit 2 n/James Lee e/jameslee@example.com`                            |
+| **Payment**| `payment INDEX [f/FEE] d/[PAYMENT_DATE]`<br> e.g., `payment 4 f/1000 d/14-11-2000`                                                                                                                                                  |
+| **Find**   | `find KEYWORD [MORE_KEYWORDS]`<br> e.g., `find James Jake`                                                                                                                                                                          |
+| **List**   | `list`                                                                                                                                                                                                                              |
+| **Help**   | `help`                                                                                                                                                                                                                              |
 

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -128,6 +128,12 @@ public class EditCommand extends Command {
                     .collect(Collectors.toSet());
         }
 
+        if (editPersonDescriptor.getTagsToAppend().isPresent()) {
+            Set<Tag> modifiableTags = new HashSet<>(updatedTags);
+            modifiableTags.addAll(editPersonDescriptor.getTagsToAppend().get());
+            updatedTags = modifiableTags;
+        }
+
 
         // Edit command does not allow editing paymentInfo
         PaymentInfo updatedPaymentInfo = personToEdit.getPaymentInfo();
@@ -174,7 +180,9 @@ public class EditCommand extends Command {
         private CurrentGrade currentGrade;
         private Set<Tag> tags;
         private Set<Tag> tagsToRemove;
+        private Set<Tag> tagsToAppend;
         private EduLevel eduLevel;
+
 
 
         public EditPersonDescriptor() {
@@ -195,6 +203,8 @@ public class EditCommand extends Command {
             setCurrentGrade(toCopy.currentGrade);
             setTags(toCopy.tags);
             setTagsToRemove(toCopy.tagsToRemove);
+            setTagsToAppend(toCopy.tagsToAppend);
+
         }
 
         /**
@@ -202,7 +212,7 @@ public class EditCommand extends Command {
          */
         public boolean isAnyFieldEdited() {
             return CollectionUtil.isAnyNonNull(name, phone, email, address, eduLevel, currentYear, currentGrade,
-                    expectedGrade, tags, tagsToRemove);
+                    expectedGrade, tags, tagsToRemove, tagsToAppend);
         }
 
         public void setName(Name name) {
@@ -314,6 +324,16 @@ public class EditCommand extends Command {
                     : Optional.empty();
         }
 
+        public void setTagsToAppend(Set<Tag> tagsToAppend) {
+            this.tagsToAppend = (tagsToAppend != null) ? new HashSet<>(tagsToAppend) : null;
+        }
+
+        public Optional<Set<Tag>> getTagsToAppend() {
+            return (tagsToAppend != null)
+                    ? Optional.of(Collections.unmodifiableSet(tagsToAppend))
+                    : Optional.empty();
+        }
+
         @Override
         public boolean equals(Object other) {
             if (other == this) {
@@ -335,7 +355,8 @@ public class EditCommand extends Command {
                     && Objects.equals(currentGrade, otherEditPersonDescriptor.currentGrade)
                     && Objects.equals(expectedGrade, otherEditPersonDescriptor.expectedGrade)
                     && Objects.equals(tags, otherEditPersonDescriptor.tags)
-                    && Objects.equals(tagsToRemove, otherEditPersonDescriptor.tagsToRemove);
+                    && Objects.equals(tagsToRemove, otherEditPersonDescriptor.tagsToRemove)
+                    && Objects.equals(tagsToAppend, otherEditPersonDescriptor.tagsToAppend);
         }
 
         @Override

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -15,6 +15,7 @@ public class CliSyntax {
     public static final Prefix PREFIX_EXP_GRADE = new Prefix("eg/");
     public static final Prefix PREFIX_TAG = new Prefix("t/");
     public static final Prefix PREFIX_TAG_REMOVE = new Prefix("t-/");
+    public static final Prefix PREFIX_TAG_APPEND = new Prefix("t+/");
     // `PREFIX_PAYMENT_FEE` and `PREFIX_PAYMENT_DATE` is part of the Payment Command
     public static final Prefix PREFIX_PAYMENT_FEE = new Prefix("f/");
     public static final Prefix PREFIX_PAYMENT_DATE = new Prefix("d/");

--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -11,6 +11,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_EXP_GRADE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG_APPEND;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG_REMOVE;
 
 import java.util.Collection;
@@ -39,7 +40,7 @@ public class EditCommandParser implements Parser<EditCommand> {
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS,
                         PREFIX_EDULEVEL, PREFIX_CURRENT_YEAR, PREFIX_CURRENT_GRADE,
-                        PREFIX_EXP_GRADE, PREFIX_TAG, PREFIX_TAG_REMOVE);
+                        PREFIX_EXP_GRADE, PREFIX_TAG, PREFIX_TAG_REMOVE, PREFIX_TAG_APPEND);
 
         Index index;
 
@@ -88,8 +89,10 @@ public class EditCommandParser implements Parser<EditCommand> {
         }
 
         parseTagsForEdit(argMultimap.getAllValues(PREFIX_TAG)).ifPresent(editPersonDescriptor::setTags);
-        parseTagsForEdit(argMultimap.getAllValues(PREFIX_TAG_REMOVE))
-                .ifPresent(editPersonDescriptor::setTagsToRemove);
+
+        parseTagsForEdit(argMultimap.getAllValues(PREFIX_TAG_REMOVE)).ifPresent(editPersonDescriptor::setTagsToRemove);
+        parseTagsForEdit(argMultimap.getAllValues(PREFIX_TAG_APPEND)).ifPresent(editPersonDescriptor::setTagsToAppend);
+
 
         if (!editPersonDescriptor.isAnyFieldEdited()) {
             throw new ParseException(EditCommand.MESSAGE_NOT_EDITED);

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -13,6 +13,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_PAYMENT_DATE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PAYMENT_FEE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG_APPEND;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG_REMOVE;
 import static seedu.address.testutil.Assert.assertThrows;
 
@@ -51,6 +52,7 @@ public class CommandTestUtil {
     public static final String VALID_GRADE_BOB = "C";
     public static final String VALID_TAG_HUSBAND = "husband";
     public static final String VALID_TAG_DONOR = "donor";
+    public static final String VALID_TAG_CLASSMATE = "classmate";
     public static final String VALID_TAG_FRIEND = "friend";
     public static final int VALID_PAYMENT_FEE = 1000;
     public static final String VALID_PAYMENT_DATE = "13-03-2025";
@@ -71,6 +73,7 @@ public class CommandTestUtil {
     public static final String EDULEVEL_DESC_BOB = " " + PREFIX_EDULEVEL + VALID_EDULEVEL_BOB;
     public static final String TAG_DESC_FRIEND = " " + PREFIX_TAG + VALID_TAG_FRIEND;
     public static final String TAG_DESC_HUSBAND = " " + PREFIX_TAG + VALID_TAG_HUSBAND;
+    public static final String TAG_DESC_CLASSMATE_TO_APPEND = " " + PREFIX_TAG_APPEND + VALID_TAG_CLASSMATE;
     public static final String TAG_DESC_DONOR_TO_REMOVE = " " + PREFIX_TAG_REMOVE + VALID_TAG_DONOR;
     public static final String PAYMENT_FEE_DESC = " " + PREFIX_PAYMENT_FEE + VALID_PAYMENT_FEE;
     public static final String PAYMENT_DATE_DESC = " " + PREFIX_PAYMENT_DATE + VALID_PAYMENT_DATE;
@@ -106,6 +109,7 @@ public class CommandTestUtil {
                 .withTags(VALID_TAG_HUSBAND, VALID_TAG_FRIEND, VALID_TAG_DONOR)
                 .withCurrentYear(VALID_EMPTY_CURRENT_YEAR)
                 .withTagsToRemove(VALID_TAG_DONOR)
+                .withTagsToAppend(VALID_TAG_CLASSMATE)
                 .withCurrentGrade(VALID_GRADE_BOB)
                 .withExpectedGrade(VALID_EXP_GRADE_BOB)
                 .build();

--- a/src/test/java/seedu/address/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditCommandTest.java
@@ -7,6 +7,7 @@ import static seedu.address.logic.commands.CommandTestUtil.DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_CLASSMATE;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_DONOR;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
@@ -57,11 +58,11 @@ public class EditCommandTest {
 
         PersonBuilder personInList = new PersonBuilder(lastPerson);
         Person editedPerson = personInList.withName(VALID_NAME_BOB).withPhone(VALID_PHONE_BOB)
-                .withTags(VALID_TAG_HUSBAND).build();
+                .withTags(VALID_TAG_HUSBAND, VALID_TAG_CLASSMATE).build();
 
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder().withName(VALID_NAME_BOB)
                 .withPhone(VALID_PHONE_BOB).withTags(VALID_TAG_HUSBAND, VALID_TAG_DONOR)
-                .withTagsToRemove(VALID_TAG_DONOR).build();
+                .withTagsToRemove(VALID_TAG_DONOR).withTagsToAppend(VALID_TAG_CLASSMATE).build();
         EditCommand editCommand = new EditCommand(indexLastPerson, descriptor);
 
         String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS, Messages.format(editedPerson));
@@ -121,6 +122,8 @@ public class EditCommandTest {
 
         assertCommandFailure(editCommand, model, EditCommand.MESSAGE_DUPLICATE_PERSON);
     }
+
+
 
     @Test
     public void execute_invalidPersonIndexUnfilteredList_failure() {

--- a/src/test/java/seedu/address/testutil/EditPersonDescriptorBuilder.java
+++ b/src/test/java/seedu/address/testutil/EditPersonDescriptorBuilder.java
@@ -130,6 +130,16 @@ public class EditPersonDescriptorBuilder {
         return this;
     }
 
+    /**
+     * Parses the {@code tags} into a {@code Set<Tag>} and appends it in the {@code EditPersonDescriptor}
+     * that we are building.
+     */
+    public EditPersonDescriptorBuilder withTagsToAppend(String... tags) {
+        Set<Tag> tagSet = Stream.of(tags).map(Tag::new).collect(Collectors.toSet());
+        descriptor.setTagsToAppend(tagSet);
+        return this;
+    }
+
     public EditPersonDescriptor build() {
         return descriptor;
     }

--- a/src/test/java/seedu/address/testutil/PersonUtil.java
+++ b/src/test/java/seedu/address/testutil/PersonUtil.java
@@ -10,6 +10,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
+import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -72,6 +73,11 @@ public class PersonUtil {
                 tags = tags.stream()
                         .filter(tag -> !tagsToRemove.contains(tag))
                         .collect(Collectors.toSet());
+            }
+            if (descriptor.getTagsToAppend().isPresent()) {
+                Set<Tag> tagsToAppend = descriptor.getTagsToAppend().get();
+                tags = new HashSet<>(tags);
+                tags.addAll(tagsToAppend);
             }
             if (tags.isEmpty()) {
                 sb.append(PREFIX_TAG);


### PR DESCRIPTION
Closes #63 

Adds functionality for t+/ to append tags without overwriting or removing existing tags.


![image](https://github.com/user-attachments/assets/2751d33a-08b1-459b-83ff-6ebb8cfb394b)

![image](https://github.com/user-attachments/assets/0557aca7-7eeb-4ef4-9f33-a08f77347421)

