### PR TITLE
Fix Expected Grade Bug

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -79,7 +79,7 @@ Format: `help`
 
 Adds a person to the address book.
 
-Format: `add n/NAME p/PHONE_NUMBER e/EMAIL a/ADDRESS [cy/CURRENT_YEAR] [cg/CURRENT_GRADE] [t/TAG]…​`
+Format: `add n/NAME p/PHONE_NUMBER e/EMAIL a/ADDRESS [l/EDU_LEVEL] [cy/CURRENT_YEAR] [cg/CURRENT_GRADE] [eg/EXP_GRADE] [t/TAG]…​`
 
 <div markdown="span" class="alert alert-primary">:bulb: **Tip:**
 A person can have any number of tags (including 0)
@@ -99,8 +99,7 @@ Format: `list`
 
 Edits an existing person in the address book.
 
-Format: `edit INDEX [n/NAME] [p/PHONE] [e/EMAIL] [a/ADDRESS] [cy/CURRENT_YEAR] [cg/CURRENT_GRADE] [t/TAG]… [t-/TAGS_TO_REMOVE]…​`
-
+Format: `edit INDEX [n/NAME] [p/PHONE] [e/EMAIL] [a/ADDRESS] [l/EDU_LEVEL] [cy/CURRENT_YEAR] [cg/CURRENT_GRADE] [eg/EXP_GRADE] [t/TAG]… [t+/TAGS_TO_APPEND]… [t-/TAGS_TO_REMOVE]…​`
 
 * Edits the person at the specified `INDEX`. The index refers to the index number shown in the displayed person list. The index **must be a positive integer** 1, 2, 3, …​
 * At least one of the optional fields must be provided.
@@ -133,6 +132,7 @@ Format: `payment INDEX [f/FEE] [d/PAYMENT_DATE]`
 * Updates the person at the specified `INDEX`. The index refers to the index number shown in the displayed person list. The index **must be a positive integer** 1, 2, 3, …​
 * Existing values will be updated to the input values.
 * If none of the optional fields are provided, the specified person's payment information will be removed.
+* `PAYMENT_DATE` should be in the format [DD-MM-YYYY]
 
 Examples:
 * `payment 1 f/1000 d/14-11-2000` Updates the tutoring fee and payment date to be `1000` and `14-11-2000` respectively.
@@ -217,14 +217,14 @@ _Details coming soon ..._
 
 ## Command summary
 
-| Action     | Format, Examples                                                                                                                                                                                                                    |
-|------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| **Add**    | `add n/NAME p/PHONE_NUMBER e/EMAIL a/ADDRESS [l/ EDUCATION_LEVEL] [cy/CURRENT_YEAR] [cg/CURRENT_GRADE] [t/TAG]…​` <br> e.g., `add n/James Ho p/22224444 e/jamesho@example.com a/123, Clementi Rd, 1234665 cg/D t/friend t/colleague` |
-| **Clear**  | `clear`                                                                                                                                                                                                                             |
-| **Delete** | `delete INDEX`<br> e.g., `delete 3`                                                                                                                                                                                                 |
-| **Edit**   | `edit INDEX [n/NAME] [p/PHONE_NUMBER] [e/EMAIL] [a/ADDRESS] [cy/CURRENT_YEAR] [cg/CURRENT_GRADE] [t/TAG]… [t-/TAGS_TO_REMOVE][t+/TAGS_TO_APPEND]…​`<br> e.g.,`edit 2 n/James Lee e/jameslee@example.com`                            |
-| **Payment**| `payment INDEX [f/FEE] d/[PAYMENT_DATE]`<br> e.g., `payment 4 f/1000 d/14-11-2000`                                                                                                                                                  |
-| **Find**   | `find KEYWORD [MORE_KEYWORDS]`<br> e.g., `find James Jake`                                                                                                                                                                          |
-| **List**   | `list`                                                                                                                                                                                                                              |
-| **Help**   | `help`                                                                                                                                                                                                                              |
+| Action     | Format, Examples                                                                                                                                                                                                                                         |
+|------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **Add**    | `add n/NAME p/PHONE_NUMBER e/EMAIL a/ADDRESS [l/ EDUCATION_LEVEL] [cy/CURRENT_YEAR] [cg/CURRENT_GRADE] [eg/EXPECTED_GRADE] [t/TAG]…​` <br> e.g., `add n/James Ho p/22224444 e/jamesho@example.com a/123, Clementi Rd, 1234665 cg/D t/friend t/colleague` |
+| **Clear**  | `clear`                                                                                                                                                                                                                                                  |
+| **Delete** | `delete INDEX`<br> e.g., `delete 3`                                                                                                                                                                                                                      |
+| **Edit**   | `edit INDEX [n/NAME] [p/PHONE_NUMBER] [e/EMAIL] [a/ADDRESS] [cy/CURRENT_YEAR] [cg/CURRENT_GRADE] [eg/EXPECTED_GRADE] [t/TAG]… [t-/TAGS_TO_REMOVE]… [t+/TAGS_TO_APPEND]…​`<br> e.g.,`edit 2 n/James Lee e/jameslee@example.com`                           |
+| **Payment**| `payment INDEX [f/FEE] d/[PAYMENT_DATE]`<br> e.g., `payment 4 f/1000 d/14-11-2000`                                                                                                                                                                       |
+| **Find**   | `find KEYWORD [MORE_KEYWORDS]`<br> e.g., `find James Jake`                                                                                                                                                                                               |
+| **List**   | `list`                                                                                                                                                                                                                                                   |
+| **Help**   | `help`                                                                                                                                                                                                                                                   |
 

--- a/docs/team/daryl.md
+++ b/docs/team/daryl.md
@@ -1,0 +1,65 @@
+---
+layout: page
+title: Daryl's Project Portfolio Page
+---
+
+### Project: TutorSynch
+
+Given below are my contributions to the project.
+
+***
+### Codebase:
+* Feature 1: Added `Current Grade` field to student's information
+    * Allows tutor to store the expected grade of the student and keep track of student's progress
+    * Tested functionality of feature with empty inputs and duplicate `eg/` fields
+
+* **Documentation**:
+    * User Guide:
+      * Added fields to command format and examples for 'add' and 'edit' command
+    * Developer Guide:
+      * Added additional Non-Functional Requirements for the project
+
+* **Community**:
+    * PRs reviewed (with non-trivial review comments): [\#61](https://github.com/AY2425S2-CS2103-F15-2/tp/pull/61)
+    
+* **Testing**
+  * Performed Smoke Testing for V1.3 [/#68](https://github.com/AY2425S2-CS2103-F15-2/tp/issues/68)
+    * Rectified bugs spotted during Smoke Testing [/#80](https://github.com/AY2425S2-CS2103-F15-2/tp/issues/80)
+
+<!--
+* **New Feature**: Added the ability to undo/redo previous commands.
+  * What it does: allows the user to undo all previous commands one at a time. Preceding undo commands can be reversed by using the redo command.
+  * Justification: This feature improves the product significantly because a user can make mistakes in commands and the app should provide a convenient way to rectify them.
+  * Highlights: This enhancement affects existing commands and commands to be added in future. It required an in-depth analysis of design alternatives. The implementation too was challenging as it required changes to existing commands.
+  * Credits: *{mention here if you reused any code/ideas from elsewhere or if a third-party library is heavily used in the feature so that a reader can make a more accurate judgement of how much effort went into the feature}*
+
+* **New Feature**: Added a history command that allows the user to navigate to previous commands using up/down keys.
+
+* **Code contributed**: [RepoSense link]()
+
+* **Project management**:
+  * Managed releases `v1.3` - `v1.5rc` (3 releases) on GitHub
+
+* **Enhancements to existing features**:
+  * Updated the GUI color scheme (Pull requests [\#33](), [\#34]())
+  * Wrote additional tests for existing features to increase coverage from 88% to 92% (Pull requests [\#36](), [\#38]())
+
+* **Documentation**:
+  * User Guide:
+    * Added documentation for the features `delete` and `find` [\#72]()
+    * Did cosmetic tweaks to existing documentation of features `clear`, `exit`: [\#74]()
+  * Developer Guide:
+    * Added implementation details of the `delete` feature.
+
+* **Community**:
+  * PRs reviewed (with non-trivial review comments): [\#12](), [\#32](), [\#19](), [\#42]()
+  * Contributed to forum discussions (examples: [1](), [2](), [3](), [4]())
+  * Reported bugs and suggestions for other teams in the class (examples: [1](), [2](), [3]())
+  * Some parts of the history feature I added was adopted by several other class mates ([1](), [2]())
+
+* **Tools**:
+  * Integrated a third party library (Natty) to the project ([\#42]())
+  * Integrated a new Github plugin (CircleCI) to the team repo
+
+* _{you can add/remove categories in the list above}_
+-->

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -255,17 +255,8 @@ public class EditCommand extends Command {
             this.expectedGrade = expectedGrade;
         }
 
-        /**
-         * Returns Optional#ExpectedGrade if an ExpectedGrade exists.
-         * Returns {@code Optional#empty()} if ExpectedGrade does not exist (null or empty).
-         */
-
         public Optional<ExpectedGrade> getExpectedGrade() {
-            if (expectedGrade == null || expectedGrade.isEmptyExpectedGrade()) {
-                return Optional.empty();
-            } else {
-                return Optional.ofNullable(expectedGrade);
-            }
+            return Optional.ofNullable(expectedGrade);
         }
 
         public Optional<EduLevel> getEduLevel() {

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -172,7 +172,7 @@ public class ParserUtil {
         if (!ExpectedGrade.isValidExpectedGrade(upperCaseCurrentGrade)) {
             throw new ParseException(ExpectedGrade.MESSAGE_CONSTRAINTS);
         }
-        return new ExpectedGrade(trimmedExpectedGrade);
+        return new ExpectedGrade(upperCaseCurrentGrade);
     }
 
     /**

--- a/src/main/java/seedu/address/model/person/ExpectedGrade.java
+++ b/src/main/java/seedu/address/model/person/ExpectedGrade.java
@@ -51,13 +51,6 @@ public class ExpectedGrade {
         return test.matches(VALIDATION_REGEX);
     }
 
-    /**
-     * Returns true if there is a grade
-     */
-    public boolean isEmptyExpectedGrade() {
-        return value.isEmpty();
-    }
-
     @Override
     public String toString() {
         return value;

--- a/src/test/java/seedu/address/model/person/ExpectedGradeTest.java
+++ b/src/test/java/seedu/address/model/person/ExpectedGradeTest.java
@@ -27,6 +27,7 @@ public class ExpectedGradeTest {
         // invalid addresses
         assertFalse(ExpectedGrade.isValidExpectedGrade(" ")); // No whitespaces allowed
         assertFalse(ExpectedGrade.isValidExpectedGrade("a")); // No small letters
+        assertFalse(CurrentGrade.isValidCurrentGrade("B%")); // wrong symbol
         assertFalse(ExpectedGrade.isValidExpectedGrade("G")); // Only A - F
         assertFalse(ExpectedGrade.isValidExpectedGrade("AB")); // Only 1 letter at most
 


### PR DESCRIPTION
- Fix expectedGrade to work such that:
1. Lower case letters `a - f` will be accepted and changed to upper case
2. Empty field `eg/` for edit removes expectedGrade from contact

- Add documentation to User Guide
- Add personal documentation to `docs/team`
- Closes bug found in #80 

Snapshots:

### Empty Field `eg/`
<img width="681" alt="Screenshot 2025-03-20 at 12 02 12 AM" src="https://github.com/user-attachments/assets/5f140ce2-07d4-4e6f-ae78-52a5aae51b87" />
<img width="667" alt="Screenshot 2025-03-20 at 12 02 18 AM" src="https://github.com/user-attachments/assets/5bfa632b-819f-47e9-b987-a358f96cf71f" />

### Lower Case Expected Grade
<img width="850" alt="Screenshot 2025-03-20 at 12 02 29 AM" src="https://github.com/user-attachments/assets/d9fb9e69-e307-4349-a39d-2ad993179fca" />
<img width="821" alt="Screenshot 2025-03-20 at 12 02 32 AM" src="https://github.com/user-attachments/assets/53bb51b8-594d-45a0-9720-84212826f3f8" />