### PR TITLE
Fix Duplicated Tag Bypass via Color Code

### DIFF
--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -121,20 +121,18 @@ public class EditCommand extends Command {
                 .orElse(personToEdit.getCurrentGrade());
         ExpectedGrade updatedExpectedGrade = editPersonDescriptor.getExpectedGrade()
                 .orElse(personToEdit.getExpectedGrade());
+        // For Tag Editing, Tag Overwrite will be processed first, followed by Tag Append, then Tag Remove.
         Set<Tag> updatedTags = editPersonDescriptor.getTags().orElse(personToEdit.getTags());
-        if (editPersonDescriptor.getTagsToRemove().isPresent()) {
-            updatedTags = updatedTags.stream()
-                    .filter(tag -> !editPersonDescriptor.getTagsToRemove().get().contains(tag))
-                    .collect(Collectors.toSet());
-        }
-
         if (editPersonDescriptor.getTagsToAppend().isPresent()) {
             Set<Tag> modifiableTags = new HashSet<>(updatedTags);
             modifiableTags.addAll(editPersonDescriptor.getTagsToAppend().get());
             updatedTags = modifiableTags;
         }
-
-
+        if (editPersonDescriptor.getTagsToRemove().isPresent()) {
+            updatedTags = updatedTags.stream()
+                    .filter(tag -> !editPersonDescriptor.getTagsToRemove().get().contains(tag))
+                    .collect(Collectors.toSet());
+        }
         // Edit command does not allow editing paymentInfo
         PaymentInfo updatedPaymentInfo = personToEdit.getPaymentInfo();
 

--- a/src/main/java/seedu/address/model/person/CurrentGrade.java
+++ b/src/main/java/seedu/address/model/person/CurrentGrade.java
@@ -23,7 +23,7 @@ public class CurrentGrade {
     public final String color;
 
     /**
-     * Constructs an {@code CurrentGrade} without specifying the level (defaults to empty string).
+     * Constructs a {@code CurrentGrade} without specifying the grade (defaults to empty string).
      */
     public CurrentGrade() {
         this.value = "";
@@ -31,7 +31,7 @@ public class CurrentGrade {
     }
 
     /**
-     * Constructs an {@code Current Grade}.
+     * Constructs a {@code CurrentGrade}.
      *
      * @param currentGrade A valid current grade.
      */

--- a/src/main/java/seedu/address/model/person/ExpectedGrade.java
+++ b/src/main/java/seedu/address/model/person/ExpectedGrade.java
@@ -24,7 +24,15 @@ public class ExpectedGrade {
     public final String color;
 
     /**
-     * Constructs a {@code Expected Grade}.
+     * Constructs an {@code ExpectedGrade} without specifying the grade (defaults to empty string).
+     */
+    public ExpectedGrade() {
+        this.value = "";
+        this.color = getGradeHexColor("");
+    }
+
+    /**
+     * Constructs an {@code ExpectedGrade}.
      *
      * @param expectedGrade A valid expected grade.
      */

--- a/src/main/java/seedu/address/model/tag/Tag.java
+++ b/src/main/java/seedu/address/model/tag/Tag.java
@@ -46,12 +46,13 @@ public class Tag {
 
         Tag otherTag = (Tag) other;
         // Tag is the same as long as the `tagName` (First half) is the same. `hexColor` (Second half) is ignored here.
-        return fullTag.split("#")[0].equals(otherTag.fullTag.split("#")[0]);
+        return fullTag.split("#")[0].equalsIgnoreCase(otherTag.fullTag.split("#")[0]);
     }
 
     @Override
     public int hashCode() {
-        return fullTag.hashCode();
+        // NOTE: hashCode() is used primarily for determining duplicated content in a HashSet.
+        return fullTag.split("#")[0].toLowerCase().hashCode();
     }
 
     /**

--- a/src/main/java/seedu/address/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/address/model/util/SampleDataUtil.java
@@ -26,36 +26,37 @@ public class SampleDataUtil {
 
     public static Person[] getSamplePersons() {
         return new Person[] {
-                new Person(new Name("Alex Yeoh"), new Phone("87438807"), new Email("alexyeoh@example.com"),
-                        new Address("Blk 30 Geylang Street 29, #06-40"), new EduLevel("Primary"), new CurrentYear("Primary 6"),
-                        new CurrentGrade("C"), new ExpectedGrade("A"), getTagSet("Math#FF5733"),
-                        new PaymentInfo(200, "12-01-2024")),
+            new Person(new Name("Alex Yeoh"), new Phone("87438807"), new Email("alexyeoh@example.com"),
+                    new Address("Blk 30 Geylang Street 29, #06-40"), new EduLevel("Primary"),
+                    new CurrentYear("Primary 6"), new CurrentGrade("C"), new ExpectedGrade("A"),
+                    getTagSet("Math#FF5733"), new PaymentInfo(200, "12-01-2024")),
 
-                new Person(new Name("Bernice Yu"), new Phone("99272758"), new Email("berniceyu@example.com"),
-                        new Address("Blk 30 Lorong 3 Serangoon Gardens, #07-18"), new EduLevel("Secondary"), new CurrentYear("Secondary 3"),
-                        new CurrentGrade("D"), new ExpectedGrade("B"), getTagSet("Physics#4287f5", "friends"),
-                        new PaymentInfo(300, "15-02-2024")),
+            new Person(new Name("Bernice Yu"), new Phone("99272758"), new Email("berniceyu@example.com"),
+                    new Address("Blk 30 Lorong 3 Serangoon Gardens, #07-18"), new EduLevel("Secondary"),
+                    new CurrentYear("Secondary 3"), new CurrentGrade("D"), new ExpectedGrade("B"),
+                    getTagSet("Physics#4287f5", "friends"),
+                    new PaymentInfo(300, "15-02-2024")),
 
-                new Person(new Name("Charlotte Oliveiro"), new Phone("93210283"), new Email("charlotte@example.com"),
-                        new Address("Blk 11 Ang Mo Kio Street 74, #11-04"), new EduLevel("Diploma"), new CurrentYear("Year 2"),
-                        new CurrentGrade("F"), new ExpectedGrade("C"), getTagSet("IT101#8e44ad"),
-                        EMPTY_PAYMENT_INFO),
+            new Person(new Name("Charlotte Oliveiro"), new Phone("93210283"), new Email("charlotte@example.com"),
+                    new Address("Blk 11 Ang Mo Kio Street 74, #11-04"), new EduLevel("Diploma"),
+                    new CurrentYear("Year 2"), new CurrentGrade("F"), new ExpectedGrade("C"),
+                    getTagSet("IT101#8e44ad"), EMPTY_PAYMENT_INFO),
 
-                new Person(new Name("David Li"), new Phone("91031282"), new Email("lidavid@example.com"),
-                        new Address("Blk 436 Serangoon Gardens Street 26, #16-43"), new EduLevel("Bachelor"),
-                        new CurrentYear("Year 4"), new CurrentGrade("B-"), new ExpectedGrade("D"),
-                        getTagSet("CS2040C#1abc9c", "classmates"),
-                        new PaymentInfo(600, "01-04-2024")),
+            new Person(new Name("David Li"), new Phone("91031282"), new Email("lidavid@example.com"),
+                    new Address("Blk 436 Serangoon Gardens Street 26, #16-43"), new EduLevel("Bachelor"),
+                    new CurrentYear("Year 4"), new CurrentGrade("B-"), new ExpectedGrade("D"),
+                    getTagSet("CS2040C#1abc9c", "classmates"),
+                    new PaymentInfo(600, "01-04-2024")),
 
-                new Person(new Name("Irfan Ibrahim"), new Phone("92492021"), new Email("irfan@example.com"),
-                        new Address("Blk 47 Tampines Street 20, #17-35"), new EduLevel("Master"), new CurrentYear("Year 2"),
-                        new CurrentGrade("C+"), new ExpectedGrade("E"), getTagSet("CS2103T#e67e22", "CS4238"),
-                        new PaymentInfo(750, "18-05-2024")),
+            new Person(new Name("Irfan Ibrahim"), new Phone("92492021"), new Email("irfan@example.com"),
+                    new Address("Blk 47 Tampines Street 20, #17-35"), new EduLevel("Master"), new CurrentYear("Year 2"),
+                    new CurrentGrade("C+"), new ExpectedGrade("E"), getTagSet("CS2103T#e67e22", "CS4238"),
+                    new PaymentInfo(750, "18-05-2024")),
 
-                new Person(new Name("Roy Balakrishnan"), new Phone("92624417"), new Email("royb@example.com"),
-                        new Address("Blk 45 Aljunied Street 85, #11-31"), new EduLevel(), new CurrentYear(),
-                        new CurrentGrade(), new ExpectedGrade(), getTagSet("CS3230#3498db"),
-                        EMPTY_PAYMENT_INFO)
+            new Person(new Name("Roy Balakrishnan"), new Phone("92624417"), new Email("royb@example.com"),
+                    new Address("Blk 45 Aljunied Street 85, #11-31"), new EduLevel(), new CurrentYear(),
+                    new CurrentGrade(), new ExpectedGrade(), getTagSet("CS3230#3498db"),
+                    EMPTY_PAYMENT_INFO)
         };
     }
 

--- a/src/main/java/seedu/address/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/address/model/util/SampleDataUtil.java
@@ -23,31 +23,39 @@ import seedu.address.model.tag.Tag;
  */
 public class SampleDataUtil {
     public static final PaymentInfo EMPTY_PAYMENT_INFO = new PaymentInfo();
-    public static final EduLevel DEFAULT_EDU_LEVEL = new EduLevel("Bachelor");
 
     public static Person[] getSamplePersons() {
         return new Person[] {
-            new Person(new Name("Alex Yeoh"), new Phone("87438807"), new Email("alexyeoh@example.com"),
-                new Address("Blk 30 Geylang Street 29, #06-40"), DEFAULT_EDU_LEVEL, new CurrentYear("Year 1"),
-                    new CurrentGrade("C"), new ExpectedGrade("A"), getTagSet("friends"), EMPTY_PAYMENT_INFO),
-            new Person(new Name("Bernice Yu"), new Phone("99272758"), new Email("berniceyu@example.com"),
-                new Address("Blk 30 Lorong 3 Serangoon Gardens, #07-18"), DEFAULT_EDU_LEVEL, new CurrentYear("Year 2"),
-                    new CurrentGrade("D"), new ExpectedGrade("B"),
-                    getTagSet("colleagues", "friends"), EMPTY_PAYMENT_INFO),
-            new Person(new Name("Charlotte Oliveiro"), new Phone("93210283"), new Email("charlotte@example.com"),
-                new Address("Blk 11 Ang Mo Kio Street 74, #11-04"), DEFAULT_EDU_LEVEL, new CurrentYear("Year 3"),
-                    new CurrentGrade("F"), new ExpectedGrade("C"), getTagSet("neighbours"), EMPTY_PAYMENT_INFO),
-            new Person(new Name("David Li"), new Phone("91031282"), new Email("lidavid@example.com"),
-                new Address("Blk 436 Serangoon Gardens Street 26, #16-43"), DEFAULT_EDU_LEVEL,
-                    new CurrentYear("Year 4"), new CurrentGrade("B-"), new ExpectedGrade("D"),
-                    getTagSet("family"), EMPTY_PAYMENT_INFO),
-            new Person(new Name("Irfan Ibrahim"), new Phone("92492021"), new Email("irfan@example.com"),
-                new Address("Blk 47 Tampines Street 20, #17-35"), DEFAULT_EDU_LEVEL, new CurrentYear("Year 2"),
-                    new CurrentGrade("C+"), new ExpectedGrade("E"),
-                    getTagSet("classmates"), EMPTY_PAYMENT_INFO),
-            new Person(new Name("Roy Balakrishnan"), new Phone("92624417"), new Email("royb@example.com"),
-                new Address("Blk 45 Aljunied Street 85, #11-31"), DEFAULT_EDU_LEVEL, new CurrentYear("Year 1"),
-                    new CurrentGrade("B"), new ExpectedGrade("F"), getTagSet("colleagues"), EMPTY_PAYMENT_INFO)
+                new Person(new Name("Alex Yeoh"), new Phone("87438807"), new Email("alexyeoh@example.com"),
+                        new Address("Blk 30 Geylang Street 29, #06-40"), new EduLevel("Primary"), new CurrentYear("Primary 6"),
+                        new CurrentGrade("C"), new ExpectedGrade("A"), getTagSet("Math#FF5733"),
+                        new PaymentInfo(200, "12-01-2024")),
+
+                new Person(new Name("Bernice Yu"), new Phone("99272758"), new Email("berniceyu@example.com"),
+                        new Address("Blk 30 Lorong 3 Serangoon Gardens, #07-18"), new EduLevel("Secondary"), new CurrentYear("Secondary 3"),
+                        new CurrentGrade("D"), new ExpectedGrade("B"), getTagSet("Physics#4287f5", "friends"),
+                        new PaymentInfo(300, "15-02-2024")),
+
+                new Person(new Name("Charlotte Oliveiro"), new Phone("93210283"), new Email("charlotte@example.com"),
+                        new Address("Blk 11 Ang Mo Kio Street 74, #11-04"), new EduLevel("Diploma"), new CurrentYear("Year 2"),
+                        new CurrentGrade("F"), new ExpectedGrade("C"), getTagSet("IT101#8e44ad"),
+                        EMPTY_PAYMENT_INFO),
+
+                new Person(new Name("David Li"), new Phone("91031282"), new Email("lidavid@example.com"),
+                        new Address("Blk 436 Serangoon Gardens Street 26, #16-43"), new EduLevel("Bachelor"),
+                        new CurrentYear("Year 4"), new CurrentGrade("B-"), new ExpectedGrade("D"),
+                        getTagSet("CS2040C#1abc9c", "classmates"),
+                        new PaymentInfo(600, "01-04-2024")),
+
+                new Person(new Name("Irfan Ibrahim"), new Phone("92492021"), new Email("irfan@example.com"),
+                        new Address("Blk 47 Tampines Street 20, #17-35"), new EduLevel("Master"), new CurrentYear("Year 2"),
+                        new CurrentGrade("C+"), new ExpectedGrade("E"), getTagSet("CS2103T#e67e22", "CS4238"),
+                        new PaymentInfo(750, "18-05-2024")),
+
+                new Person(new Name("Roy Balakrishnan"), new Phone("92624417"), new Email("royb@example.com"),
+                        new Address("Blk 45 Aljunied Street 85, #11-31"), new EduLevel(), new CurrentYear(),
+                        new CurrentGrade(), new ExpectedGrade(), getTagSet("CS3230#3498db"),
+                        EMPTY_PAYMENT_INFO)
         };
     }
 

--- a/src/test/java/seedu/address/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditCommandTest.java
@@ -123,8 +123,6 @@ public class EditCommandTest {
         assertCommandFailure(editCommand, model, EditCommand.MESSAGE_DUPLICATE_PERSON);
     }
 
-
-
     @Test
     public void execute_invalidPersonIndexUnfilteredList_failure() {
         Index outOfBoundIndex = Index.fromOneBased(model.getFilteredPersonList().size() + 1);
@@ -149,6 +147,27 @@ public class EditCommandTest {
                 new EditPersonDescriptorBuilder().withName(VALID_NAME_BOB).build());
 
         assertCommandFailure(editCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+    }
+
+    /**
+     * Edit
+     */
+    @Test
+    public void execute_test_success() {
+        Person editedPerson = new PersonBuilder().withTags().build();
+        EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder(editedPerson)
+                .withTags("Math#FF5733", "Physics", "PE").withTagsToAppend("Chemistry", "Math", "History")
+                .withTagsToRemove("PE", "Chemistry").build();
+        EditCommand editCommand = new EditCommand(INDEX_FIRST_PERSON, descriptor);
+
+        String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS, Messages.format(
+                new PersonBuilder().withTags("Physics", "Math#FF5733", "History").build()));
+
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+        expectedModel.setPerson(model.getFilteredPersonList().get(0), new PersonBuilder()
+                .withTags("Physics", "Math#FF5733", "History").build());
+
+        assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
     }
 
     @Test


### PR DESCRIPTION
Fixes #82 
## Changes includes:
- [X] Updated the proper ordering of Tag Editing (Tag Overwrite > Tag Append > Tag Removal).
- [X] Added `ExpectedGrade()` constructor.
- [X] Updated `hashCode()` for Tags (Used in `HashSet` to determine if an element exist in the Set)
- [X] Updated `SampleDataUtil.java`
## Screenshots:
![image](https://github.com/user-attachments/assets/39cfac64-9171-41bd-ba9d-c29e720e02e4)
### Command used:
- `edit 1 t/Math#FF5733 t/Physics t/PE t-/PE t-/Chemistry t+/Chemistry t+/Math t+/History`

![image](https://github.com/user-attachments/assets/a99e7ea3-7f0c-42ae-8287-c70db1ef952a)
### Command used:
- `add n/Benny p/12345678 e/benny@example.com a/AFGNHSJGASJHG t/ Math#ABCDEF t/MATH t/math t/ math#ABCDEF t/ math#BCBCBC t/MATH#ABFDEF`
