### PR TITLE
Fix running pointer bug in clearCommand

### DIFF
--- a/src/main/java/seedu/address/logic/commands/ClearCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ClearCommand.java
@@ -32,7 +32,7 @@ public class ClearCommand extends Command {
 
     public static final String MESSAGE_SUCCESS = "Number of persons removed successfully: %1$s";
     public static final String MESSAGE_SUCCESS_INDEX = "%d. Deleted persons from index %d to %d";
-    public static final String MESSAGE_SUCCESS_TAG = "%d. Persons deleted had tags: %s";
+    public static final String MESSAGE_SUCCESS_TAG = "%d. Person(s) deleted had at least one of these tag(s): %s";
     public static final String MESSAGE_NO_PERSONS_FOUND = "0. No persons found with the tags: %s.";
     public static final String MESSAGE_INVALID_INDEX_RANGE = "Invalid index range provided. End index must be "
             + "strictly greater than start index";
@@ -95,7 +95,7 @@ public class ClearCommand extends Command {
             throw new CommandException(MESSAGE_INVALID_INDEX_RANGE);
         }
 
-        List<Person> subListToDelete = lastShownList.subList(start.getZeroBased(), end.getZeroBased() + 1);
+        List<Person> subListToDelete = lastShownList.subList(start.getZeroBased(), end.getZeroBased() + 1).stream().toList();
         subListToDelete.forEach(model::deletePerson);
 
         int numberOfPersonsDeleted = end.getZeroBased() - start.getZeroBased() + 1;

--- a/src/main/java/seedu/address/logic/commands/UntagCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UntagCommand.java
@@ -25,7 +25,7 @@ public class UntagCommand extends Command {
             + PREFIX_TAG + "CS2030";
 
     public static final String MESSAGE_SUCCESS = "The following tags have been cleared: %1$s.\n"
-            + "%2$d person had their tags updated.";
+            + "%2$d person(s) had their tags updated.";
     public static final String MESSAGE_NO_PERSON_UPDATED = "No persons were updated as no matching tags were found.";
 
     private final Set<Tag> tagsToRemove;

--- a/src/test/java/seedu/address/logic/commands/ClearCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ClearCommandTest.java
@@ -3,8 +3,10 @@ package seedu.address.logic.commands;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static seedu.address.logic.commands.ClearCommand.MESSAGE_INVALID_INDEX_RANGE;
+import static seedu.address.logic.commands.ClearCommand.MESSAGE_NO_PERSONS_FOUND;
 import static seedu.address.logic.commands.ClearCommand.MESSAGE_SUCCESS;
 import static seedu.address.logic.commands.ClearCommand.MESSAGE_SUCCESS_INDEX;
+import static seedu.address.logic.commands.ClearCommand.MESSAGE_SUCCESS_TAG;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.testutil.Assert.assertThrows;
@@ -44,7 +46,9 @@ public class ClearCommandTest {
 
         Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
         List<Person> personsToRemove = expectedModel.getFilteredPersonList()
-                .subList(INDEX_FIRST_PERSON.getZeroBased(), INDEX_SECOND_PERSON.getZeroBased() + 1);
+                .subList(INDEX_FIRST_PERSON.getZeroBased(), INDEX_SECOND_PERSON.getZeroBased() + 1)
+                .stream().toList();
+
         personsToRemove.forEach(expectedModel::deletePerson);
         assertCommandSuccess(clearCommand, model, expectedMessage, expectedModel);
     }
@@ -65,7 +69,8 @@ public class ClearCommandTest {
 
         ClearCommand clearCommand = new ClearCommand(targetTags);
         String expectedMessage = String
-                .format(MESSAGE_SUCCESS, "3. Persons deleted had tags: [[friends]]");
+                .format(MESSAGE_SUCCESS,
+                        String.format(MESSAGE_SUCCESS_TAG, 3, targetTags.toString()));
 
         // Simulate tag-based deletion results for the expected model
         Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
@@ -84,7 +89,7 @@ public class ClearCommandTest {
 
         ClearCommand clearCommand = new ClearCommand(nonMatchingTags);
         String expectedMessage = String.format(MESSAGE_SUCCESS,
-                String.format(ClearCommand.MESSAGE_NO_PERSONS_FOUND, nonMatchingTags.toString()));
+                String.format(MESSAGE_NO_PERSONS_FOUND, nonMatchingTags.toString()));
 
         assertCommandSuccess(clearCommand, model, expectedMessage, model);
     }


### PR DESCRIPTION
Fix #116, closes #111 

### Notes:
* Fix issue in ClearCommand where different people from the indices stated were deleted.
* Update output message to be clearer.