### PR TITLE
Add input limit to Name, Address, Email and Current Year

### DIFF
--- a/src/main/java/seedu/address/model/person/Address.java
+++ b/src/main/java/seedu/address/model/person/Address.java
@@ -9,7 +9,7 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
  */
 public class Address {
 
-    public static final int MAX_LENGTH = 150;
+    public static final int MAX_LENGTH = 255;
 
     public static final String MESSAGE_CONSTRAINTS = String.format("Addresses can take any values, "
             + "but should not be blank and must not exceed %d characters", MAX_LENGTH);

--- a/src/main/java/seedu/address/model/person/Address.java
+++ b/src/main/java/seedu/address/model/person/Address.java
@@ -9,7 +9,7 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
  */
 public class Address {
 
-    public static final int MAX_LENGTH = 255;
+    public static final int MAX_LENGTH = 110;
 
     public static final String MESSAGE_CONSTRAINTS = String.format("Addresses can take any values, "
             + "but should not be blank and must not exceed %d characters", MAX_LENGTH);

--- a/src/main/java/seedu/address/model/person/Address.java
+++ b/src/main/java/seedu/address/model/person/Address.java
@@ -9,7 +9,10 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
  */
 public class Address {
 
-    public static final String MESSAGE_CONSTRAINTS = "Addresses can take any values, and it should not be blank";
+    public static final int MAX_LENGTH = 150;
+
+    public static final String MESSAGE_CONSTRAINTS = String.format("Addresses can take any values, "
+            + "but should not be blank and must not exceed %d characters", MAX_LENGTH);
 
     /*
      * The first character of the address must not be a whitespace,
@@ -34,7 +37,16 @@ public class Address {
      * Returns true if a given string is a valid email.
      */
     public static boolean isValidAddress(String test) {
-        return test.matches(VALIDATION_REGEX);
+        return test.matches(VALIDATION_REGEX) && isValidLength(test);
+    }
+
+    /**
+     * Check length of address against limit
+     * @param test
+     * @return Returns true if given address exceeds max length
+     */
+    public static boolean isValidLength(String test) {
+        return test.length() <= MAX_LENGTH;
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/CurrentYear.java
+++ b/src/main/java/seedu/address/model/person/CurrentYear.java
@@ -9,7 +9,7 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
  */
 public class CurrentYear {
 
-    public static final int MAX_LENGTH = 25;
+    public static final int MAX_LENGTH = 255;
 
     public static final String MESSAGE_CONSTRAINTS =
             String.format("Current Year should only contain alphanumeric characters and "

--- a/src/main/java/seedu/address/model/person/CurrentYear.java
+++ b/src/main/java/seedu/address/model/person/CurrentYear.java
@@ -9,7 +9,7 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
  */
 public class CurrentYear {
 
-    public static final int MAX_LENGTH = 255;
+    public static final int MAX_LENGTH = 30;
 
     public static final String MESSAGE_CONSTRAINTS =
             String.format("Current Year should only contain alphanumeric characters and "

--- a/src/main/java/seedu/address/model/person/CurrentYear.java
+++ b/src/main/java/seedu/address/model/person/CurrentYear.java
@@ -9,8 +9,11 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
  */
 public class CurrentYear {
 
+    public static final int MAX_LENGTH = 25;
+
     public static final String MESSAGE_CONSTRAINTS =
-            "Current Year should only contain alphanumeric characters and spaces. "
+            String.format("Current Year should only contain alphanumeric characters and "
+                    + "spaces and must not exceed %d characters. ", MAX_LENGTH)
                     + "As Current Year is an optional field, it could also be blank.";
 
     public static final String VALIDATION_REGEX = "[\\p{Alnum} ]*";
@@ -35,7 +38,16 @@ public class CurrentYear {
      * Returns true if a given string is a valid current year.
      */
     public static boolean isValidCurrentYear(String test) {
-        return test.matches(VALIDATION_REGEX);
+        return test.matches(VALIDATION_REGEX) && isValidLength(test);
+    }
+
+    /**
+     * Check length of current year against limit
+     * @param test
+     * @return Returns true if given current year exceeds max length
+     */
+    public static boolean isValidLength(String test) {
+        return test.length() <= MAX_LENGTH;
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/Email.java
+++ b/src/main/java/seedu/address/model/person/Email.java
@@ -9,7 +9,7 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
  */
 public class Email {
 
-    public static final int MAX_LENGTH = 255;
+    public static final int MAX_LENGTH = 110;
     private static final String SPECIAL_CHARACTERS = "+_.-";
     public static final String MESSAGE_CONSTRAINTS = "Emails should be of the format local-part@domain "
             + "and adhere to the following constraints:\n"

--- a/src/main/java/seedu/address/model/person/Email.java
+++ b/src/main/java/seedu/address/model/person/Email.java
@@ -9,7 +9,7 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
  */
 public class Email {
 
-    public static final int MAX_LENGTH = 254;
+    public static final int MAX_LENGTH = 255;
     private static final String SPECIAL_CHARACTERS = "+_.-";
     public static final String MESSAGE_CONSTRAINTS = "Emails should be of the format local-part@domain "
             + "and adhere to the following constraints:\n"

--- a/src/main/java/seedu/address/model/person/Email.java
+++ b/src/main/java/seedu/address/model/person/Email.java
@@ -9,6 +9,7 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
  */
 public class Email {
 
+    public static final int MAX_LENGTH = 254;
     private static final String SPECIAL_CHARACTERS = "+_.-";
     public static final String MESSAGE_CONSTRAINTS = "Emails should be of the format local-part@domain "
             + "and adhere to the following constraints:\n"
@@ -20,7 +21,8 @@ public class Email {
             + "The domain name must:\n"
             + "    - end with a domain label at least 2 characters long\n"
             + "    - have each domain label start and end with alphanumeric characters\n"
-            + "    - have each domain label consist of alphanumeric characters, separated only by hyphens, if any.";
+            + "    - have each domain label consist of alphanumeric characters, separated only by hyphens, if any.\n"
+            + String.format("3. Email must not exceed %d characters.", MAX_LENGTH);
     // alphanumeric and special characters
     private static final String ALPHANUMERIC_NO_UNDERSCORE = "[^\\W_]+"; // alphanumeric characters except underscore
     private static final String LOCAL_PART_REGEX = "^" + ALPHANUMERIC_NO_UNDERSCORE + "([" + SPECIAL_CHARACTERS + "]"
@@ -48,7 +50,16 @@ public class Email {
      * Returns if a given string is a valid email.
      */
     public static boolean isValidEmail(String test) {
-        return test.matches(VALIDATION_REGEX);
+        return test.matches(VALIDATION_REGEX) && isValidLength(test);
+    }
+
+    /**
+     * Check length of email against limit
+     * @param test
+     * @return Returns true if given email exceeds max length
+     */
+    public static boolean isValidLength(String test) {
+        return test.length() <= MAX_LENGTH;
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/Name.java
+++ b/src/main/java/seedu/address/model/person/Name.java
@@ -8,7 +8,7 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
  * Guarantees: immutable; is valid as declared in {@link #isValidName(String)}
  */
 public class Name {
-    public static final int MAX_LENGTH = 255;
+    public static final int MAX_LENGTH = 85;
 
     public static final String MESSAGE_CONSTRAINTS =
             String.format("Names should only contain alphanumeric characters and spaces, should not be blank, "

--- a/src/main/java/seedu/address/model/person/Name.java
+++ b/src/main/java/seedu/address/model/person/Name.java
@@ -8,9 +8,11 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
  * Guarantees: immutable; is valid as declared in {@link #isValidName(String)}
  */
 public class Name {
+    public static final int MAX_LENGTH = 100;
 
     public static final String MESSAGE_CONSTRAINTS =
-            "Names should only contain alphanumeric characters and spaces, and it should not be blank";
+            String.format("Names should only contain alphanumeric characters and spaces, should not be blank, "
+                            + "and must not exceed %d characters.", MAX_LENGTH);
 
     /*
      * The first character of the address must not be a whitespace,
@@ -35,9 +37,17 @@ public class Name {
      * Returns true if a given string is a valid name.
      */
     public static boolean isValidName(String test) {
-        return test.matches(VALIDATION_REGEX);
+        return test.matches(VALIDATION_REGEX) && isValidLength(test);
     }
 
+    /**
+     * Check length of name against limit
+     * @param test
+     * @return Returns true if given name exceeds max length
+     */
+    public static boolean isValidLength(String test) {
+        return test.length() <= MAX_LENGTH;
+    }
 
     @Override
     public String toString() {

--- a/src/main/java/seedu/address/model/person/Name.java
+++ b/src/main/java/seedu/address/model/person/Name.java
@@ -8,7 +8,7 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
  * Guarantees: immutable; is valid as declared in {@link #isValidName(String)}
  */
 public class Name {
-    public static final int MAX_LENGTH = 100;
+    public static final int MAX_LENGTH = 255;
 
     public static final String MESSAGE_CONSTRAINTS =
             String.format("Names should only contain alphanumeric characters and spaces, should not be blank, "

--- a/src/test/java/seedu/address/model/person/AddressTest.java
+++ b/src/test/java/seedu/address/model/person/AddressTest.java
@@ -24,6 +24,14 @@ public class AddressTest {
         // Valid address
         assertTrue(Address.isValidLength("Blk 123 @ The Best Place"));
 
+        // Email length of 110 - valid as within limit
+        assertTrue(Address.isValidLength("abcdefghijklmnopqrstabcdefghijklmnopqrstabcdefghijklmnopqrst"
+                + "abcdefghijklmnopqrstabcdefghijklmnopqrstabcdefghij"));
+
+        // Email length of 111 - invalid as exceeds limit
+        assertFalse(Address.isValidLength("abcdefghijklmnopqrstabcdefghijklmnopqrstabcdefghijklmnopqrst"
+                + "abcdefghijklmnopqrstabcdefghijklmnopqrstabcdefghijK"));
+
         // Super long string - meant to fail
         assertFalse(Address.isValidLength(
                 "Absurdly long string that is meant to fail and it should fail and only fail and cannot pass. "

--- a/src/test/java/seedu/address/model/person/AddressTest.java
+++ b/src/test/java/seedu/address/model/person/AddressTest.java
@@ -20,6 +20,25 @@ public class AddressTest {
     }
 
     @Test
+    public void isValidLength() {
+        // Valid address
+        assertTrue(Address.isValidLength("Blk 123 @ The Best Place"));
+
+        // Super long string - meant to fail
+        assertFalse(Address.isValidLength(
+                "Absurdly long string that is meant to fail and it should fail and only fail and cannot pass. "
+                + "Absurdly long string that is meant to fail and it should fail and only fail and cannot pass. "
+                + "Absurdly long string that is meant to fail and it should fail and only fail and cannot pass. "
+                + "Absurdly long string that is meant to fail and it should fail and only fail and cannot pass. "
+                + "Absurdly long string that is meant to fail and it should fail and only fail and cannot pass. "
+                + "Absurdly long string that is meant to fail and it should fail and only fail and cannot pass. "
+                + "Absurdly long string that is meant to fail and it should fail and only fail and cannot pass. "
+                + "Absurdly long string that is meant to fail and it should fail and only fail and cannot pass. "
+                + "Absurdly long string that is meant to fail and it should fail and only fail and cannot pass. "
+                + "Absurdly long string that is meant to fail and it should fail and only fail and cannot pass."));
+    }
+
+    @Test
     public void isValidAddress() {
         // null address
         assertThrows(NullPointerException.class, () -> Address.isValidAddress(null));

--- a/src/test/java/seedu/address/model/person/CurrentYearTest.java
+++ b/src/test/java/seedu/address/model/person/CurrentYearTest.java
@@ -20,6 +20,25 @@ public class CurrentYearTest {
     }
 
     @Test
+    public void isValidLength() {
+        // Valid current year
+        assertTrue(CurrentYear.isValidLength("Sophomore"));
+
+        // Super long string - meant to fail
+        assertFalse(CurrentYear.isValidLength(
+                "Absurdly long string that is meant to fail and it should fail and only fail and not pass. "
+                        + "Absurdly long string that is meant to fail and it should fail and only fail and not pass. "
+                        + "Absurdly long string that is meant to fail and it should fail and only fail and not pass. "
+                        + "Absurdly long string that is meant to fail and it should fail and only fail and not pass. "
+                        + "Absurdly long string that is meant to fail and it should fail and only fail and not pass. "
+                        + "Absurdly long string that is meant to fail and it should fail and only fail and not pass. "
+                        + "Absurdly long string that is meant to fail and it should fail and only fail and not pass. "
+                        + "Absurdly long string that is meant to fail and it should fail and only fail and not pass. "
+                        + "Absurdly long string that is meant to fail and it should fail and only fail and not pass. "
+                        + "Absurdly long string that is meant to fail and it should fail and only fail and not pass."));
+    }
+
+    @Test
     public void isValidCurrentYear() {
         // null current year
         assertThrows(NullPointerException.class, () -> CurrentYear.isValidCurrentYear(null));

--- a/src/test/java/seedu/address/model/person/CurrentYearTest.java
+++ b/src/test/java/seedu/address/model/person/CurrentYearTest.java
@@ -24,6 +24,12 @@ public class CurrentYearTest {
         // Valid current year
         assertTrue(CurrentYear.isValidLength("Sophomore"));
 
+        // 30 characters - valid as within limit
+        assertTrue(CurrentYear.isValidLength("abcdefghijklmnopqrstabcdefghij"));
+
+        // 31 characters - invalid as exceeds limit
+        assertFalse(CurrentYear.isValidLength("abcdefghijklmnopqrstabcdefghijK"));
+
         // Super long string - meant to fail
         assertFalse(CurrentYear.isValidLength(
                 "Absurdly long string that is meant to fail and it should fail and only fail and not pass. "

--- a/src/test/java/seedu/address/model/person/EmailTest.java
+++ b/src/test/java/seedu/address/model/person/EmailTest.java
@@ -20,6 +20,25 @@ public class EmailTest {
     }
 
     @Test
+    public void isValidLength() {
+        // Valid email
+        assertTrue(Email.isValidLength("test@gmail.com"));
+
+        // Super long email - meant to fail
+        assertFalse(Email.isValidLength(
+                "Absurdlylongemailthatismeanttofailanditshouldfailandonlyfailandnotpass"
+                        + "Absurdlylongemailthatismeanttofailanditshouldfailandonlyfailandnotpass"
+                        + "Absurdlylongemailthatismeanttofailanditshouldfailandonlyfailandnotpass"
+                        + "Absurdlylongemailthatismeanttofailanditshouldfailandonlyfailandnotpass"
+                        + "Absurdlylongemailthatismeanttofailanditshouldfailandonlyfailandnotpass"
+                        + "Absurdlylongemailthatismeanttofailanditshouldfailandonlyfailandnotpass"
+                        + "Absurdlylongemailthatismeanttofailanditshouldfailandonlyfailandnotpass"
+                        + "Absurdlylongemailthatismeanttofailanditshouldfailandonlyfailandnotpass"
+                        + "Absurdlylongemailthatismeanttofailanditshouldfailandonlyfailandnotpass"
+                        + "@gmail.com"));
+    }
+
+    @Test
     public void isValidEmail() {
         // null email
         assertThrows(NullPointerException.class, () -> Email.isValidEmail(null));

--- a/src/test/java/seedu/address/model/person/EmailTest.java
+++ b/src/test/java/seedu/address/model/person/EmailTest.java
@@ -24,6 +24,14 @@ public class EmailTest {
         // Valid email
         assertTrue(Email.isValidLength("test@gmail.com"));
 
+        // Email length of 110 - valid as within limit
+        assertTrue(Email.isValidLength("abcdefghijklmnopqrstabcdefghijklmnopqrstabcdefghijklmnopqrst"
+                + "abcdefghijklmnopqrstabcdefghijklmnopqrst@gmail.com"));
+
+        // Email length of 111 - invalid as exceeds limit
+        assertFalse(Email.isValidLength("abcdefghijklmnopqrstabcdefghijklmnopqrstabcdefghijklmnopqrst"
+                + "abcdefghijklmnopqrstabcdefghijklmnopqrstA@gmail.com"));
+
         // Super long email - meant to fail
         assertFalse(Email.isValidLength(
                 "Absurdlylongemailthatismeanttofailanditshouldfailandonlyfailandnotpass"

--- a/src/test/java/seedu/address/model/person/NameTest.java
+++ b/src/test/java/seedu/address/model/person/NameTest.java
@@ -24,7 +24,15 @@ public class NameTest {
         // Valid name
         assertTrue(Name.isValidLength("Stephanie Tan Tik Tok"));
 
-        // Super long string - meant to fail
+        // 85 characters - Valid as within limit
+        assertTrue(Name.isValidLength("abcdefghijklmnopqrstabcdefghijklmnopqrstabcdefghijklmnopqrst"
+                + "abcdefghijklmnopqrstabcde"));
+
+        // 86 characters - Invalid as exceeds limit
+        assertFalse(Name.isValidLength("abcdefghijklmnopqrstabcdefghijklmnopqrstabcdefghijklmnopqrst"
+                + "abcdefghijklmnopqrstabcdeF"));
+
+        // Super long string - Invalid as exceeds limit
         assertFalse(Name.isValidLength(
                 "Absurdly long string that is meant to fail and it should fail and only fail and not pass. "
                         + "Absurdly long string that is meant to fail and it should fail and only fail and not pass. "

--- a/src/test/java/seedu/address/model/person/NameTest.java
+++ b/src/test/java/seedu/address/model/person/NameTest.java
@@ -20,6 +20,25 @@ public class NameTest {
     }
 
     @Test
+    public void isValidLength() {
+        // Valid name
+        assertTrue(Name.isValidLength("Stephanie Tan Tik Tok"));
+
+        // Super long string - meant to fail
+        assertFalse(Name.isValidLength(
+                "Absurdly long string that is meant to fail and it should fail and only fail and not pass. "
+                        + "Absurdly long string that is meant to fail and it should fail and only fail and not pass. "
+                        + "Absurdly long string that is meant to fail and it should fail and only fail and not pass. "
+                        + "Absurdly long string that is meant to fail and it should fail and only fail and not pass. "
+                        + "Absurdly long string that is meant to fail and it should fail and only fail and not pass. "
+                        + "Absurdly long string that is meant to fail and it should fail and only fail and not pass. "
+                        + "Absurdly long string that is meant to fail and it should fail and only fail and not pass. "
+                        + "Absurdly long string that is meant to fail and it should fail and only fail and not pass. "
+                        + "Absurdly long string that is meant to fail and it should fail and only fail and not pass. "
+                        + "Absurdly long string that is meant to fail and it should fail and only fail and not pass."));
+    }
+
+    @Test
     public void isValidName() {
         // null name
         assertThrows(NullPointerException.class, () -> Name.isValidName(null));


### PR DESCRIPTION
Resolves #121 

Update fields with open String input parameters to have a limit. This helps to ensure that all characters entered into string input fields are fully visible, a character limit will be applied. This limit is based on the screen width of a typical 14-inch.
It is guaranteed that fields will be fully visible if application is open in full-screen for a 14-inch notebook, otherwise it may have some wrapping.

The following features have the limits
- **Name** has a limit of **85** characters.
- **Email** has a limit of **110** characters.
- **Address** has a limit of **110** characters.
- **CurrentYear** has a limit of **30** characters.

