### PR TITLE
Update minimum Window size and Tag Limitations

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -52,7 +52,7 @@ TutorSynch is a **desktop app for managing student contacts and academic details
 * Items in square brackets are optional.<br>
   e.g. `n/NAME [t/TAG]` can be used as `n/John Doe t/friend` or as `n/John Doe`.
 
-* Items with `…` after them can be used multiple times including zero times.<br>
+* Items with `…` after them can be used less than or equals to 8 times, including zero times.<br>
   e.g. `[t/TAG]…` can be used as ` ` (i.e. 0 times), `t/cs4238`, `t/cs2103 t/GEA1000` etc.
 
 * Any tags can be written as an alphanumeric tag, accompanied by `#` followed by 6 hexadecimal color code. (E.g. `CS2040C#ED9E49`)
@@ -66,6 +66,26 @@ TutorSynch is a **desktop app for managing student contacts and academic details
   e.g. if the command specifies `help 123`, it will be interpreted as `help`.
 
 * If you are using a PDF version of this document, be careful when copying and pasting commands that span multiple lines as space characters surrounding line-breaks may be omitted when copied over to the application.
+</div>
+
+<div markdown="span" class="alert alert-warning">:exclamation: **Constraints:**<br>
+
+* NAME must be between 1 and 85 characters. (Do note that extremely long NAME may be truncated unless you increase the window size)
+
+* EMAIL must be between 1 and 110 characters. (Do note that extremely long EMAIL may be truncated unless you increase the window size)
+
+* ADDRESS must be between 1 and 110 characters. (Do note that extremely long ADDRESS may be truncated unless you increase the window size)
+
+* CURRENT_YEAR must be between 1 and 30 characters.
+
+* Each TAG (before the optional #HEX code) must be alphanumeric and at most 10 characters.
+
+* Tags can include an optional hexadecimal color code in the format #RRGGBB (e.g., t/cs2040#FFAABB).
+
+* A maximum of 8 unique TAGs is allowed per person.
+
+* Parameters must conform to their respective formats and constraints; otherwise, the command may be rejected.
+
 </div>
 
 ### Viewing help : `help`
@@ -84,12 +104,17 @@ Adds a person to the address book.
 Format: `add n/NAME p/PHONE_NUMBER e/EMAIL a/ADDRESS [l/EDU_LEVEL] [cy/CURRENT_YEAR] [cg/CURRENT_GRADE] [eg/EXP_GRADE] [t/TAG]…​`
 
 <div markdown="span" class="alert alert-primary">:bulb: **Tip:**
-A person can have any number of tags (including 0)
+A person can have less than or equals to 8 unique tags each (including 0).
+</div>
+
+<div markdown="span" class="alert alert-primary">:bulb: **Tip:**
+You can add a hexadecimal color code to any tag by appending `#RRGGBB` after the tag name.
+For example: `t/CS2040#ED9E49`. This allows tags to be visually color-coded in the UI.
 </div>
 
 Examples:
 * `add n/John Doe p/98765432 e/johnd@example.com a/John street, block 123, #01-01`
-* `add n/Betsy Crowe t/friend e/betsycrowe@example.com a/Newgate Prison p/1234567 cg/C+ t/cs2040s`
+* `add n/Betsy Crowe t/friend e/betsycrowe@example.com a/Newgate Prison p/1234567 cg/C+ t/CS2030C`
 
 ### Listing all persons : `list`
 
@@ -107,6 +132,15 @@ Format: `edit INDEX [n/NAME] [p/PHONE] [e/EMAIL] [a/ADDRESS] [l/EDU_LEVEL] [cy/C
 * At least one of the optional fields must be provided.
 * Existing values will be updated to the input values.
 
+<div markdown="span" class="alert alert-primary">:bulb: **Tip:**
+A person can have less than or equals to 8 unique tags each (including 0).
+</div>
+
+<div markdown="span" class="alert alert-primary">:bulb: **Tip:**
+You can add a hexadecimal color code to any tag by appending `#RRGGBB` after the tag name.
+For example: `t/CS2040#ED9E49`. This allows tags to be visually color-coded in the UI.
+</div>
+
 Examples:
 *  `edit 1 p/91234567 e/johndoe@example.com` Edits the phone number and email address of the 1st person to be `91234567` and `johndoe@example.com` respectively.
 
@@ -116,13 +150,13 @@ Examples:
 1. Tags prefixed with `t/` form the new list of tags (overwriting the old tags), if none are provided, old list of tags is used for the next steps.
 2. Tags prefixed with `t+/` are added to the current list. If the tag already exists, the updated list remains unchanged as tags are unique.
 3. Tags prefixed with `t-/` are removed from the list provided by the last step. If the tag to be removed does not exist, the app silently continues with the rest.
-4. The final tag list is updated to the person.
+4. The final tag list is updated to the person, and should have less than or equals to 8 unique tags.
 
 Examples:
 *  `edit 2 n/Betsy Crower t/` Edits the name of the 2nd person to be `Betsy Crower` and clears all existing tags.
 *  `edit 2 t-/Maths` Edits the tags of the 2nd person by removing `Maths` from existing list of tags.
 *  `edit 1 t/Maths t/Science t-/Science ` Edits the tags of the 2nd person by clearing all existing tags and adding **only** `Maths`.
-*  `edit 1 t+/friend t+/owesMoney` appends friend and owesMoney to existing tags (without overwriting or removing).
+*  `edit 1 t+/friend t+/CS2030C#1E3BC3` appends `friend` and `CS2030C#1E3BC3` to existing tags (without overwriting or removing).
 
 ### Bulk removal of tags: `untag`
 
@@ -262,16 +296,17 @@ If your changes to the data file makes its format invalid, TutorSynch will disca
 Furthermore, certain edits can cause the TutorSynch to behave in unexpected ways (e.g., if a value entered is outside the acceptable range). Therefore, edit the data file only if you are confident that you can update it correctly.
 </div>
 
-### Archiving data files `[coming in v2.0]`
-
-_Details coming soon ..._
-
 --------------------------------------------------------------------------------------------------------------------
 
 ## FAQ
 
 **Q**: How do I transfer my data to another Computer?<br>
-**A**: Install the app in the other computer and overwrite the empty data file it creates with the file that contains the data of your previous TutorSynch home folder.
+**A**: Install the app on the other computer. After it runs once, it will create a default data file at `[JAR file location]/data/addressbook.json`. To transfer your data, overwrite this file with the `addressbook.json` file from your original computer.
+
+<div markdown="span" class="alert alert-warning">:exclamation: **Caution:**
+Before doing this, ensure that the data file is valid and has not been corrupted or manually edited in a way that breaks the expected format. Invalid or out-of-range values may cause TutorSynch to start with an empty data file or behave unpredictably.<br>
+It's strongly recommended to make a backup of your data file before any manual edits or transfers.
+</div>
 
 --------------------------------------------------------------------------------------------------------------------
 
@@ -279,24 +314,25 @@ _Details coming soon ..._
 
 1. **When using multiple screens**, if you move the application to a secondary screen, and later switch to using only the primary screen, the GUI will open off-screen. The remedy is to delete the `preferences.json` file created by the application before running the application again.
 2. **If you minimize the Help Window** and then run the `help` command (or use the `Help` menu, or the keyboard shortcut `F1`) again, the original Help Window will remain minimized, and no new Help Window will appear. The remedy is to manually restore the minimized Help Window.
+3. **If you need to see your truncated NAME, EMAIL or ADDRESS**, increase your window size for the application until it is no longer truncated.
 
 --------------------------------------------------------------------------------------------------------------------
 
 ## Command summary
 
-| Action           | Format, Examples                                                                                                                                                                                                                                        |
-|------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| **Add**          | `add n/NAME p/PHONE_NUMBER e/EMAIL a/ADDRESS [l/ EDUCATION_LEVEL] [cy/CURRENT_YEAR] [cg/CURRENT_GRADE] [eg/EXPECTED_GRADE] [t/TAG]…` <br> e.g., `add n/James Ho p/22224444 e/jamesho@example.com a/123, Clementi Rd, 1234665 cg/D t/friend t/colleague` |
-| **Purge**        | `purge`                                                                                                                                                                                                                                                 |
-| **Delete**       | `delete INDEX`<br> e.g., `delete 3`                                                                                                                                                                                                                     |
-| **Clear**        | `clear i/START_INDEX...END_INDEX` OR `clear t/TAG [t/TAG]`                                                                                                                                                                                              |
-| **Edit**         | `edit INDEX [n/NAME] [p/PHONE_NUMBER] [e/EMAIL] [a/ADDRESS] [cy/CURRENT_YEAR] [cg/CURRENT_GRADE] [eg/EXPECTED_GRADE] [t/TAG]… [t+/TAGS_TO_APPEND]… [t-/TAGS_TO_REMOVE]…`<br> e.g.,`edit 2 n/James Lee e/jameslee@example.com t+/CS2040C#1E2C4D`         |
-| **Untag**        | `untag t/TAG [t/TAG]...`<br> e.g., `untag t/Math t/Science`                                                                                                                                                                                             |
-| **Payment**      | `payment INDEX [f/FEE] [d/PAYMENT_DATE] [s/PAYMENT_STATUS]`<br> e.g., `payment 1 f/1000 d/14-11-2000 s/paid`                                                                                                                                            |
-| **Find**         | `find KEYWORD [MORE_KEYWORDS]`<br> e.g., `find James Jake`                                                                                                                                                                                              |
-| **Sort**         | `sort`                                                                                                                                                                                                                                                  |
-| **Filter**       | `filter [l/EDU_LEVEL] [cg/CURRENT_GRADE] [eg/EXP_GRADE] [t/TAG]…`                                                                                                                                                                                       |
-| **List**         | `list`                                                                                                                                                                                                                                                  |
-| **Help**         | `help`                                                                                                                                                                                                                                                  |
-| **Switch Theme** | `toggletheme`                                                                                                                                                                                                                                           |
-| **Exit**         | `exit`                                                                                                                                                                                                                                                  |
+| Action           | Format, Examples                                                                                                                                                                                                                                       |
+|------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **Add**          | `add n/NAME p/PHONE_NUMBER e/EMAIL a/ADDRESS [l/ EDUCATION_LEVEL] [cy/CURRENT_YEAR] [cg/CURRENT_GRADE] [eg/EXPECTED_GRADE] [t/TAG]…` <br> e.g., `add n/James Ho p/22224444 e/jamesho@example.com a/123, Clementi Rd, 1234665 cg/D t/CS2030C t/friends` |
+| **Purge**        | `purge`                                                                                                                                                                                                                                                |
+| **Delete**       | `delete INDEX`<br> e.g., `delete 3`                                                                                                                                                                                                                    |
+| **Clear**        | `clear i/START_INDEX...END_INDEX` OR `clear t/TAG [t/TAG]`                                                                                                                                                                                             |
+| **Edit**         | `edit INDEX [n/NAME] [p/PHONE_NUMBER] [e/EMAIL] [a/ADDRESS] [cy/CURRENT_YEAR] [cg/CURRENT_GRADE] [eg/EXPECTED_GRADE] [t/TAG]… [t+/TAGS_TO_APPEND]… [t-/TAGS_TO_REMOVE]…`<br> e.g.,`edit 2 n/James Lee e/jameslee@example.com t+/CS2040C#1E2C4D`        |
+| **Untag**        | `untag t/TAG [t/TAG]...`<br> e.g., `untag t/Math t/Science`                                                                                                                                                                                            |
+| **Payment**      | `payment INDEX [f/FEE] [d/PAYMENT_DATE] [s/PAYMENT_STATUS]`<br> e.g., `payment 1 f/1000 d/14-11-2000 s/paid`                                                                                                                                           |
+| **Find**         | `find KEYWORD [MORE_KEYWORDS]`<br> e.g., `find James Jake`                                                                                                                                                                                             |
+| **Sort**         | `sort`                                                                                                                                                                                                                                                 |
+| **Filter**       | `filter [l/EDU_LEVEL] [cg/CURRENT_GRADE] [eg/EXP_GRADE] [t/TAG]…`                                                                                                                                                                                      |
+| **List**         | `list`                                                                                                                                                                                                                                                 |
+| **Help**         | `help`                                                                                                                                                                                                                                                 |
+| **Switch Theme** | `toggletheme`                                                                                                                                                                                                                                          |
+| **Exit**         | `exit`                                                                                                                                                                                                                                                 |

--- a/docs/team/benny.md
+++ b/docs/team/benny.md
@@ -15,6 +15,9 @@ Given below are my contributions to the project.
 * **New Feature**: Updated payment information to contain payment status. [\#101](https://github.com/AY2425S2-CS2103-F15-2/tp/pull/101)
   * Highlights: Contains `PaymentInfo.Builder` to dynamically build a `PaymentInfo` object, instead of using multiple manually-defined constructors.
 
+* **Project management**:
+  * Managed releases `v1.3` - `v1.4` (2 releases) on GitHub
+
 * **Documentation**:
   * Ui Mockup:
     * Designed `docs\images\Ui.png` and `docs\images\findLeeYuResult.png` via PowerPoint. [\#38](https://github.com/AY2425S2-CS2103-F15-2/tp/pull/38)
@@ -22,9 +25,10 @@ Given below are my contributions to the project.
     * Did cosmetic tweaks to existing documentations mentioning `AddressBook` instead of `TutorSynch`. [\#46](https://github.com/AY2425S2-CS2103-F15-2/tp/pull/46)
     * Added documentation for the feature `payment`. [\#59](https://github.com/AY2425S2-CS2103-F15-2/tp/pull/59)
     * Updated documentation for `paymentStatus` for the feature `payment`. [\#101](https://github.com/AY2425S2-CS2103-F15-2/tp/pull/101)
+    * Updated documentation for Parameter Constraints (i.e. NAME, EMAIL, ADDRESS, & TAG). [\#128](https://github.com/AY2425S2-CS2103-F15-2/tp/pull/128)
   * Developer Guide:
-    * Modified existing use cases for `UC01 - Add a new student`, `UC03 - Delete a student`, and `UC04 - List all students`. [\#46](https://github.com/AY2425S2-CS2103-F15-2/tp/pull/46)
-    * Added use cases for `UC02 - Edit a student's information`, `UC05 - Record payment information for existing student`, `UC06 - Bulk delete student records`, `UC07 - Compare progress between two students`. [\#46](https://github.com/AY2425S2-CS2103-F15-2/tp/pull/46)
+    * Modified existing use cases for `UC01`, `UC03`, and `UC04`. [\#46](https://github.com/AY2425S2-CS2103-F15-2/tp/pull/46)
+    * Added use cases for `UC02`, `UC05`, `UC06`, `UC07`. [\#46](https://github.com/AY2425S2-CS2103-F15-2/tp/pull/46)
 
 * **Community**:
   * PRs reviewed (with non-trivial review comments): [\#58](https://github.com/AY2425S2-CS2103-F15-2/tp/pull/58#pullrequestreview-2686240341)
@@ -32,44 +36,8 @@ Given below are my contributions to the project.
 * **Testing**:
   * Performed minor Smoke Testing for V1.3. [\#68](https://github.com/AY2425S2-CS2103-F15-2/tp/issues/68)
     * Bugs spotted during minor Smoke Testing: [\#81](https://github.com/AY2425S2-CS2103-F15-2/tp/issues/81), [\#82](https://github.com/AY2425S2-CS2103-F15-2/tp/issues/82)
+  * Performed minor Smoke Testing for V1.4. [\#100](https://github.com/AY2425S2-CS2103-F15-2/tp/issues/100)
+    * Bugs spotted during minor Smoke Testing: [\#116](https://github.com/AY2425S2-CS2103-F15-2/tp/issues/116)
 
 * **Bug Fixes**:
-  * Rectified the following bugs: [\#84](https://github.com/AY2425S2-CS2103-F15-2/tp/pull/84), [\#85](https://github.com/AY2425S2-CS2103-F15-2/tp/pull/85)
-
-<!--
-* **New Feature**: Added the ability to undo/redo previous commands.
-  * What it does: allows the user to undo all previous commands one at a time. Preceding undo commands can be reversed by using the redo command.
-  * Justification: This feature improves the product significantly because a user can make mistakes in commands and the app should provide a convenient way to rectify them.
-  * Highlights: This enhancement affects existing commands and commands to be added in future. It required an in-depth analysis of design alternatives. The implementation too was challenging as it required changes to existing commands.
-  * Credits: *{mention here if you reused any code/ideas from elsewhere or if a third-party library is heavily used in the feature so that a reader can make a more accurate judgement of how much effort went into the feature}*
-
-* **New Feature**: Added a history command that allows the user to navigate to previous commands using up/down keys.
-
-* **Code contributed**: [RepoSense link]()
-
-* **Project management**:
-  * Managed releases `v1.3` - `v1.5rc` (3 releases) on GitHub
-
-* **Enhancements to existing features**:
-  * Updated the GUI color scheme (Pull requests [\#33](), [\#34]())
-  * Wrote additional tests for existing features to increase coverage from 88% to 92% (Pull requests [\#36](), [\#38]())
-
-* **Documentation**:
-  * User Guide:
-    * Added documentation for the features `delete` and `find` [\#72]()
-    * Did cosmetic tweaks to existing documentation of features `clear`, `exit`: [\#74]()
-  * Developer Guide:
-    * Added implementation details of the `delete` feature.
-
-* **Community**:
-  * PRs reviewed (with non-trivial review comments): [\#12](), [\#32](), [\#19](), [\#42]()
-  * Contributed to forum discussions (examples: [1](), [2](), [3](), [4]())
-  * Reported bugs and suggestions for other teams in the class (examples: [1](), [2](), [3]())
-  * Some parts of the history feature I added was adopted by several other class mates ([1](), [2]())
-
-* **Tools**:
-  * Integrated a third party library (Natty) to the project ([\#42]())
-  * Integrated a new Github plugin (CircleCI) to the team repo
-
-* _{you can add/remove categories in the list above}_
--->
+  * Rectified the following bugs: [\#84](https://github.com/AY2425S2-CS2103-F15-2/tp/pull/84), [\#85](https://github.com/AY2425S2-CS2103-F15-2/tp/pull/85), [\#115](https://github.com/AY2425S2-CS2103-F15-2/tp/issues/115)

--- a/src/main/java/seedu/address/commons/core/GuiSettings.java
+++ b/src/main/java/seedu/address/commons/core/GuiSettings.java
@@ -13,7 +13,7 @@ import seedu.address.commons.util.ToStringBuilder;
 public class GuiSettings implements Serializable {
 
     private static final double DEFAULT_HEIGHT = 600;
-    private static final double DEFAULT_WIDTH = 1060;
+    private static final double DEFAULT_WIDTH = 1080;
 
     private final double windowWidth;
     private final double windowHeight;

--- a/src/main/java/seedu/address/commons/core/GuiSettings.java
+++ b/src/main/java/seedu/address/commons/core/GuiSettings.java
@@ -13,7 +13,7 @@ import seedu.address.commons.util.ToStringBuilder;
 public class GuiSettings implements Serializable {
 
     private static final double DEFAULT_HEIGHT = 600;
-    private static final double DEFAULT_WIDTH = 740;
+    private static final double DEFAULT_WIDTH = 1060;
 
     private final double windowWidth;
     private final double windowHeight;

--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -44,8 +44,8 @@ public class AddCommand extends Command {
             + PREFIX_CURRENT_YEAR + "Year 1 "
             + PREFIX_CURRENT_GRADE + "C "
             + PREFIX_EXP_GRADE + "A "
-            + PREFIX_TAG + "friends "
-            + PREFIX_TAG + "owesMoney ";
+            + PREFIX_TAG + "CS2030C "
+            + PREFIX_TAG + "GEA1000 ";
 
     public static final String MESSAGE_SUCCESS = "New person added: %1$s";
     public static final String MESSAGE_DUPLICATE_PERSON = "This person already exists in the address book";

--- a/src/main/java/seedu/address/logic/commands/ClearCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ClearCommand.java
@@ -28,7 +28,7 @@ public class ClearCommand extends Command {
             + "Parameters:  " + PREFIX_INDEX_SEQUENCE + "START...END OR "
             + PREFIX_TAG + "TAG" + " [" + PREFIX_TAG + "TAG]...\n"
             + "Example: " + COMMAND_WORD + " " + PREFIX_INDEX_SEQUENCE + "1...5"
-            + " OR " + COMMAND_WORD + " " + PREFIX_TAG + "friends " + PREFIX_TAG + "colleagues";
+            + " OR " + COMMAND_WORD + " " + PREFIX_TAG + "CS2030C " + PREFIX_TAG + "GEA1000";
 
     public static final String MESSAGE_SUCCESS = "Number of persons removed successfully: %1$s";
     public static final String MESSAGE_SUCCESS_INDEX = "%d. Deleted persons from index %d to %d";

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -99,6 +99,10 @@ public class EditCommand extends Command {
             throw new CommandException(MESSAGE_DUPLICATE_PERSON);
         }
 
+        if (editedPerson.getTags().size() > Tag.MAX_TAGS_IN_SET) {
+            throw new CommandException(Tag.MESSAGE_CONSTRAINTS_EDIT_SET);
+        }
+
         model.setPerson(personToEdit, editedPerson);
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
         return new CommandResult(String.format(MESSAGE_EDIT_PERSON_SUCCESS, Messages.format(editedPerson)));
@@ -177,8 +181,8 @@ public class EditCommand extends Command {
         private CurrentYear currentYear;
         private CurrentGrade currentGrade;
         private Set<Tag> tags;
-        private Set<Tag> tagsToRemove;
         private Set<Tag> tagsToAppend;
+        private Set<Tag> tagsToRemove;
         private EduLevel eduLevel;
 
 
@@ -200,8 +204,8 @@ public class EditCommand extends Command {
             setCurrentYear(toCopy.currentYear);
             setCurrentGrade(toCopy.currentGrade);
             setTags(toCopy.tags);
-            setTagsToRemove(toCopy.tagsToRemove);
             setTagsToAppend(toCopy.tagsToAppend);
+            setTagsToRemove(toCopy.tagsToRemove);
 
         }
 
@@ -344,8 +348,8 @@ public class EditCommand extends Command {
                     && Objects.equals(currentGrade, otherEditPersonDescriptor.currentGrade)
                     && Objects.equals(expectedGrade, otherEditPersonDescriptor.expectedGrade)
                     && Objects.equals(tags, otherEditPersonDescriptor.tags)
-                    && Objects.equals(tagsToRemove, otherEditPersonDescriptor.tagsToRemove)
-                    && Objects.equals(tagsToAppend, otherEditPersonDescriptor.tagsToAppend);
+                    && Objects.equals(tagsToAppend, otherEditPersonDescriptor.tagsToAppend)
+                    && Objects.equals(tagsToRemove, otherEditPersonDescriptor.tagsToRemove);
         }
 
         @Override
@@ -360,6 +364,8 @@ public class EditCommand extends Command {
                     .add("currentGrade", currentGrade)
                     .add("expectedGrade", expectedGrade)
                     .add("tags", tags)
+                    .add("tagsToAppend", tagsToAppend)
+                    .add("tagsToRemove", tagsToRemove)
                     .toString();
         }
     }

--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -58,6 +58,9 @@ public class AddCommandParser implements Parser<AddCommand> {
         EduLevel eduLevel = ParserUtil.parseEduLevel(argMultimap.getValue(PREFIX_EDULEVEL).orElse(""));
 
         Set<Tag> tagList = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
+        if (tagList.size() > Tag.MAX_TAGS_IN_SET) {
+            throw new ParseException(Tag.MESSAGE_CONSTRAINTS_ADD_SET);
+        }
         CurrentYear currentYear = ParserUtil.parseCurrentYear(argMultimap.getValue(PREFIX_CURRENT_YEAR)
             .orElse(""));
         CurrentGrade currentGrade = ParserUtil.parseCurrentGrade(argMultimap

--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -89,9 +89,8 @@ public class EditCommandParser implements Parser<EditCommand> {
         }
 
         parseTagsForEdit(argMultimap.getAllValues(PREFIX_TAG)).ifPresent(editPersonDescriptor::setTags);
-
-        parseTagsForEdit(argMultimap.getAllValues(PREFIX_TAG_REMOVE)).ifPresent(editPersonDescriptor::setTagsToRemove);
         parseTagsForEdit(argMultimap.getAllValues(PREFIX_TAG_APPEND)).ifPresent(editPersonDescriptor::setTagsToAppend);
+        parseTagsForEdit(argMultimap.getAllValues(PREFIX_TAG_REMOVE)).ifPresent(editPersonDescriptor::setTagsToRemove);
 
 
         if (!editPersonDescriptor.isAnyFieldEdited()) {

--- a/src/main/java/seedu/address/model/tag/Tag.java
+++ b/src/main/java/seedu/address/model/tag/Tag.java
@@ -9,9 +9,14 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
  */
 public class Tag {
 
-    public static final String MESSAGE_CONSTRAINTS = "Tags names should be alphanumeric, while its color codes should"
-            + "be 6 hexadecimal long (e.g. \"CS2040C#F2552E\")";
-    public static final String VALIDATION_REGEX = "^(\\p{Alnum}+)(?:#([A-Fa-f0-9]{6}))?$";
+    public static final String VALIDATION_REGEX = "^(\\p{Alnum}{1,10})(?:#([A-Fa-f0-9]{6}))?$";
+    public static final int MAX_TAGS_IN_SET = 8;
+    public static final String MESSAGE_CONSTRAINTS = "Tags names should be alphanumeric and less than 10 characters "
+            + "long, while its color codes should be 6 hexadecimal long (e.g. \"CS2040C#F2552E\")";
+    public static final String MESSAGE_CONSTRAINTS_ADD_SET = "There can at most be " + MAX_TAGS_IN_SET
+            + " unique tags per person.";
+    public static final String MESSAGE_CONSTRAINTS_EDIT_SET = "The resulting set of tags should at most contain "
+            + MAX_TAGS_IN_SET + " tags per person.";
 
     public final String fullTag;
 

--- a/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
@@ -170,6 +170,9 @@ class JsonAdaptedPerson {
         final ExpectedGrade modelExpectedGrade = new ExpectedGrade(expectedGrade);
 
         final Set<Tag> modelTags = new HashSet<>(personTags);
+        if (modelTags.size() > Tag.MAX_TAGS_IN_SET) {
+            throw new IllegalValueException(Tag.MESSAGE_CONSTRAINTS_ADD_SET);
+        }
 
         // IF paymentFee field is missing, it will be set as 0 by default. Therefore, no checks needed.
         if (!PaymentInfo.isValidFee(paymentFee)) {

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -13,7 +13,7 @@
 <?import javafx.scene.control.Button?>
 
 <fx:root type="javafx.stage.Stage" xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1"
-         title="Address App" minWidth="1060" minHeight="600" onCloseRequest="#handleExit">
+         title="Address App" minWidth="1080" minHeight="600" onCloseRequest="#handleExit">
   <icons>
     <Image url="@/images/address_book_32.png" />
   </icons>

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -13,7 +13,7 @@
 <?import javafx.scene.control.Button?>
 
 <fx:root type="javafx.stage.Stage" xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1"
-         title="Address App" minWidth="450" minHeight="600" onCloseRequest="#handleExit">
+         title="Address App" minWidth="1060" minHeight="600" onCloseRequest="#handleExit">
   <icons>
     <Image url="@/images/address_book_32.png" />
   </icons>

--- a/src/main/resources/view/PersonListCard.fxml
+++ b/src/main/resources/view/PersonListCard.fxml
@@ -14,8 +14,8 @@
 
     <GridPane HBox.hgrow="ALWAYS">
         <columnConstraints>
-            <ColumnConstraints hgrow="SOMETIMES" minWidth="10" prefWidth="150" />
-            <ColumnConstraints hgrow="SOMETIMES" minWidth="10" prefWidth="150" />
+            <ColumnConstraints hgrow="SOMETIMES" minWidth="10" prefWidth="150" percentWidth="60" />
+            <ColumnConstraints hgrow="SOMETIMES" minWidth="10" prefWidth="150" percentWidth="40" />
         </columnConstraints>
         <VBox fx:id="personCardLeft" alignment="CENTER_LEFT" minHeight="105" GridPane.columnIndex="0" GridPane.vgrow="ALWAYS">
             <padding>

--- a/src/test/data/JsonSerializableAddressBookTest/duplicatePersonAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/duplicatePersonAddressBook.json
@@ -8,7 +8,7 @@
     "currentYear": "Year 3",
     "currentGrade" : "C",
     "expectedGrade": "",
-    "tags": [ "friends" ]
+    "tags": [ "CS2030C" ]
   }, {
     "name": "Alice Pauline",
     "phone": "94351253",

--- a/src/test/data/JsonSerializableAddressBookTest/typicalPersonsAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/typicalPersonsAddressBook.json
@@ -9,7 +9,7 @@
     "currentYear" : "Year 3",
     "currentGrade": "D",
     "expectedGrade": "A",
-    "tags" : [ "friends" ],
+    "tags" : [ "CS2030C" ],
     "paymentFee" : 0,
     "paymentDate" : "",
     "paymentStatus" : ""
@@ -22,7 +22,7 @@
     "currentYear" : "Year 4",
     "currentGrade": "B-",
     "expectedGrade": "B",
-    "tags" : [ "owesMoney", "friends" ],
+    "tags" : [ "GEA1000", "CS2030C" ],
     "paymentFee" : 500,
     "paymentDate" : "",
     "paymentStatus" : "Paid"
@@ -46,7 +46,7 @@
     "eduLevel": "Master",
     "currentGrade": "",
     "expectedGrade": "D",
-    "tags" : [ "friends" ],
+    "tags" : [ "CS2030C" ],
     "paymentFee" : 1000,
     "paymentDate" : "22-04-2025",
     "paymentStatus" : "Paid"

--- a/src/test/java/seedu/address/commons/core/GuiSettingsTest.java
+++ b/src/test/java/seedu/address/commons/core/GuiSettingsTest.java
@@ -9,10 +9,10 @@ public class GuiSettingsTest {
     public void testGuiSettings() {
         GuiSettings guiSettings = new GuiSettings();
 
-        assertEquals(guiSettings.getWindowWidth(), 740);
-        assertEquals(guiSettings.getWindowHeight(), 600);
-        assertEquals(guiSettings.getWindowCoordinates(), null);
-        assertEquals(guiSettings.getIsDarkTheme(), true);
+        assertEquals(1080, guiSettings.getWindowWidth());
+        assertEquals(600, guiSettings.getWindowHeight());
+        assertEquals(null, guiSettings.getWindowCoordinates());
+        assertEquals(true, guiSettings.getIsDarkTheme());
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/ClearCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ClearCommandTest.java
@@ -65,7 +65,7 @@ public class ClearCommandTest {
     public void execute_validTag_success() {
         // Simulate clearing by tag
         Set<Tag> targetTags = new HashSet<>();
-        targetTags.add(new Tag("friends"));
+        targetTags.add(new Tag("CS2030C"));
 
         ClearCommand clearCommand = new ClearCommand(targetTags);
         String expectedMessage = String
@@ -75,7 +75,7 @@ public class ClearCommandTest {
         // Simulate tag-based deletion results for the expected model
         Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
         model.getFilteredPersonList().stream()
-                .filter(person -> person.getTags().contains(new Tag("friends")))
+                .filter(person -> person.getTags().contains(new Tag("CS2030C")))
                 .forEach(expectedModel::deletePerson);
 
         assertCommandSuccess(clearCommand, model, expectedMessage, expectedModel);
@@ -85,7 +85,7 @@ public class ClearCommandTest {
     public void execute_noMatchingTags_success() {
         // Simulate clearing when no persons match the provided tag
         Set<Tag> nonMatchingTags = new HashSet<>();
-        nonMatchingTags.add(new Tag("nonexistent"));
+        nonMatchingTags.add(new Tag("nonexist"));
 
         ClearCommand clearCommand = new ClearCommand(nonMatchingTags);
         String expectedMessage = String.format(MESSAGE_SUCCESS,
@@ -109,11 +109,11 @@ public class ClearCommandTest {
 
         // Commands with tag-based clearing
         Set<Tag> targetTags1 = new HashSet<>();
-        targetTags1.add(new Tag("friends"));
+        targetTags1.add(new Tag("CS2030C"));
         ClearCommand clearByTagCommand1 = new ClearCommand(targetTags1);
 
         Set<Tag> targetTags2 = new HashSet<>();
-        targetTags2.add(new Tag("colleagues"));
+        targetTags2.add(new Tag("GEA1000"));
         ClearCommand clearByTagCommand2 = new ClearCommand(targetTags2);
 
         // Same object => true
@@ -125,7 +125,7 @@ public class ClearCommandTest {
 
         // Same values for tag-based command => true
         Set<Tag> targetTags1Copy = new HashSet<>();
-        targetTags1Copy.add(new Tag("friends"));
+        targetTags1Copy.add(new Tag("CS2030C"));
         ClearCommand clearByTagCommand1Copy = new ClearCommand(targetTags1Copy);
         assertEquals(clearByTagCommand1, clearByTagCommand1Copy);
 

--- a/src/test/java/seedu/address/logic/commands/ClearCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ClearCommandTest.java
@@ -149,12 +149,12 @@ public class ClearCommandTest {
     @Test
     public void toStringMethod() {
         Set<Tag> targetTags = new HashSet<>();
-        targetTags.add(new Tag("friends"));
+        targetTags.add(new Tag("CS2030C"));
 
         ClearCommand clearByTagCommand = new ClearCommand(targetTags);
         ClearCommand clearByIndexCommand = new ClearCommand(INDEX_FIRST_PERSON, INDEX_SECOND_PERSON);
 
-        assertEquals(ClearCommand.class.getCanonicalName() + "{tags=[[friends]]}",
+        assertEquals(ClearCommand.class.getCanonicalName() + "{tags=[[CS2030C]]}",
                 clearByTagCommand.toString());
         assertEquals(ClearCommand.class.getCanonicalName() + "{start=1, end=2}",
                 clearByIndexCommand.toString());

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -15,8 +15,6 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_PAYMENT_FEE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PAYMENT_STATUS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG_APPEND;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG_REMOVE;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 import static seedu.address.testutil.TypicalIndexes.INDEX_THIRD_PERSON;
@@ -78,8 +76,6 @@ public class CommandTestUtil {
     public static final String EDULEVEL_DESC_BOB = " " + PREFIX_EDULEVEL + VALID_EDULEVEL_BOB;
     public static final String TAG_DESC_FRIEND = " " + PREFIX_TAG + VALID_TAG_FRIEND;
     public static final String TAG_DESC_HUSBAND = " " + PREFIX_TAG + VALID_TAG_HUSBAND;
-    public static final String TAG_DESC_CLASSMATE_TO_APPEND = " " + PREFIX_TAG_APPEND + VALID_TAG_CLASSMATE;
-    public static final String TAG_DESC_DONOR_TO_REMOVE = " " + PREFIX_TAG_REMOVE + VALID_TAG_DONOR;
     public static final String PAYMENT_FEE_DESC = " " + PREFIX_PAYMENT_FEE + VALID_PAYMENT_FEE;
     public static final String PAYMENT_DATE_DESC = " " + PREFIX_PAYMENT_DATE + VALID_PAYMENT_DATE;
     public static final String PAYMENT_STATUS_DESC = " " + PREFIX_PAYMENT_STATUS + VALID_PAYMENT_STATUS;

--- a/src/test/java/seedu/address/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditCommandTest.java
@@ -27,6 +27,7 @@ import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
 import seedu.address.model.person.Person;
+import seedu.address.model.tag.Tag;
 import seedu.address.testutil.EditPersonDescriptorBuilder;
 import seedu.address.testutil.PersonBuilder;
 
@@ -150,10 +151,11 @@ public class EditCommandTest {
     }
 
     /**
-     * Edit
+     * Tests successful execution of an EditCommand that combines full tag overwrite, tag append, and tag removal,
+     * inclusive of Tag containing valid Hexadecimal Color Code.
      */
     @Test
-    public void execute_test_success() {
+    public void execute_editWithTagOverwriteAppendRemove_success() {
         Person editedPerson = new PersonBuilder().withTags().build();
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder(editedPerson)
                 .withTags("Math#FF5733", "Physics", "PE").withTagsToAppend("Chemistry", "Math", "History")
@@ -169,6 +171,33 @@ public class EditCommandTest {
 
         assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
     }
+
+    @Test
+    public void execute_editWithTooManyFinalTags_failure() {
+        // Base tags: 6 tags that will remain after overwrite
+        String[] baseTags = {"Tag1", "Tag2", "Tag3", "Tag4", "Tag5", "Tag6"};
+
+        // Tags to append: 3 more unique tags (total would become 10)
+        String[] tagsToAppend = {"Tag7", "Tag8", "Tag9", "Tag10#ABCDEF"};
+
+        // Tags to remove: only 1 tag removed, so final set = (6 + 4 - 1) = 9
+        String[] tagsToRemove = {"Tag9", "Tag11"};
+
+        // Build person and descriptor
+        Person editedPerson = new PersonBuilder().withTags(baseTags).build();
+
+        EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder(editedPerson)
+                .withTags(baseTags) // Overwrite with 6 base tags
+                .withTagsToAppend(tagsToAppend) // Append 4 more
+                .withTagsToRemove(tagsToRemove) // Remove 1 tag
+                .build();
+
+        EditCommand editCommand = new EditCommand(INDEX_FIRST_PERSON, descriptor);
+
+        // Expect failure due to exceeding tag limit
+        assertCommandFailure(editCommand, model, Tag.MESSAGE_CONSTRAINTS_EDIT_SET);
+    }
+
 
     @Test
     public void equals() {

--- a/src/test/java/seedu/address/logic/commands/EditPersonDescriptorTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditPersonDescriptorTest.java
@@ -79,7 +79,9 @@ public class EditPersonDescriptorTest {
                 + ", currentYear=" + editPersonDescriptor.getCurrentYear().orElse(null)
                 + ", currentGrade=" + editPersonDescriptor.getCurrentGrade().orElse(null)
                 + ", expectedGrade=" + editPersonDescriptor.getExpectedGrade().orElse(null)
-                + ", tags=" + editPersonDescriptor.getTags().orElse(null) + "}";
+                + ", tags=" + editPersonDescriptor.getTags().orElse(null)
+                + ", tagsToAppend=" + editPersonDescriptor.getTagsToAppend().orElse(null)
+                + ", tagsToRemove=" + editPersonDescriptor.getTagsToRemove().orElse(null) + "}";
         assertEquals(expected, editPersonDescriptor.toString());
     }
 }

--- a/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
@@ -228,7 +228,7 @@ public class AddCommandParserTest {
 
         // invalid grade
         assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB
-                + EDULEVEL_DESC_BOB + TAG_DESC_HUSBAND + VALID_TAG_FRIEND + INVALID_GRADE_DESC + VALID_EXP_GRADE_BOB,
+                + EDULEVEL_DESC_BOB + TAG_DESC_HUSBAND + TAG_DESC_FRIEND + INVALID_GRADE_DESC + VALID_EXP_GRADE_BOB,
                 CurrentGrade.MESSAGE_CONSTRAINTS);
 
         // invalid expected grade

--- a/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
@@ -204,31 +204,37 @@ public class AddCommandParserTest {
     public void parse_invalidValue_failure() {
         // invalid name
         assertParseFailure(parser, INVALID_NAME_DESC + PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB
-                + EDULEVEL_DESC_BOB + TAG_DESC_HUSBAND + TAG_DESC_FRIEND + VALID_GRADE_BOB
-                        + VALID_EXP_GRADE_BOB, Name.MESSAGE_CONSTRAINTS);
+                + EDULEVEL_DESC_BOB + TAG_DESC_HUSBAND + TAG_DESC_FRIEND
+                        + " cg/" + VALID_GRADE_BOB + " eg/" + VALID_EXP_GRADE_BOB,
+                Name.MESSAGE_CONSTRAINTS);
 
         // invalid phone
         assertParseFailure(parser, NAME_DESC_BOB + INVALID_PHONE_DESC + EMAIL_DESC_BOB + ADDRESS_DESC_BOB
-                + EDULEVEL_DESC_BOB + TAG_DESC_HUSBAND + TAG_DESC_FRIEND + VALID_GRADE_BOB
-                + VALID_EXP_GRADE_BOB, Phone.MESSAGE_CONSTRAINTS);
+                + EDULEVEL_DESC_BOB + TAG_DESC_HUSBAND + TAG_DESC_FRIEND
+                        + " cg/" + VALID_GRADE_BOB + " eg/" + VALID_EXP_GRADE_BOB,
+                Phone.MESSAGE_CONSTRAINTS);
 
         // invalid email
         assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + INVALID_EMAIL_DESC + ADDRESS_DESC_BOB
-                + EDULEVEL_DESC_BOB + TAG_DESC_HUSBAND + TAG_DESC_FRIEND + VALID_GRADE_BOB
-                + VALID_EXP_GRADE_BOB, Email.MESSAGE_CONSTRAINTS);
+                + EDULEVEL_DESC_BOB + TAG_DESC_HUSBAND + TAG_DESC_FRIEND
+                        + " cg/" + VALID_GRADE_BOB + " eg/" + VALID_EXP_GRADE_BOB,
+                Email.MESSAGE_CONSTRAINTS);
 
         // invalid address
         assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + INVALID_ADDRESS_DESC
-                + EDULEVEL_DESC_BOB + TAG_DESC_HUSBAND + TAG_DESC_FRIEND + VALID_GRADE_BOB + VALID_EXP_GRADE_BOB,
+                + EDULEVEL_DESC_BOB + TAG_DESC_HUSBAND + TAG_DESC_FRIEND
+                        + " cg/" + VALID_GRADE_BOB + " eg/" + VALID_EXP_GRADE_BOB,
                 Address.MESSAGE_CONSTRAINTS);
 
         // invalid tag
         assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB
-                + INVALID_TAG_DESC + VALID_TAG_FRIEND + VALID_GRADE_BOB + VALID_EXP_GRADE_BOB, Tag.MESSAGE_CONSTRAINTS);
+                + INVALID_TAG_DESC + VALID_TAG_FRIEND + " cg/" + VALID_GRADE_BOB + " eg/" + VALID_EXP_GRADE_BOB,
+                Tag.MESSAGE_CONSTRAINTS);
 
         // invalid grade
         assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB
-                + EDULEVEL_DESC_BOB + TAG_DESC_HUSBAND + TAG_DESC_FRIEND + INVALID_GRADE_DESC + VALID_EXP_GRADE_BOB,
+                + EDULEVEL_DESC_BOB + TAG_DESC_HUSBAND + TAG_DESC_FRIEND + INVALID_GRADE_DESC
+                        + " eg/" + VALID_EXP_GRADE_BOB,
                 CurrentGrade.MESSAGE_CONSTRAINTS);
 
         // invalid expected grade
@@ -243,5 +249,13 @@ public class AddCommandParserTest {
         assertParseFailure(parser, PREAMBLE_NON_EMPTY + NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB
                 + ADDRESS_DESC_BOB + TAG_DESC_HUSBAND + TAG_DESC_FRIEND,
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_overMaxTagInSet_failure() {
+        // number of tags is over the maximum limit
+        assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB
+                + EDULEVEL_DESC_BOB + " cg/" + VALID_GRADE_BOB + " eg/" + VALID_EXP_GRADE_BOB
+                + " t/1001 t/1002 t/1003 t/1004 t/1005 t/1006 t/1007 t/1008 t/1009", Tag.MESSAGE_CONSTRAINTS_ADD_SET);
     }
 }

--- a/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
@@ -182,6 +182,32 @@ public class JsonAdaptedPersonTest {
                         VALID_CURRENT_YEAR, VALID_CURRENT_GRADE, VALID_EXP_GRADE,
                         invalidTags, VALID_PAYMENT_FEE, VALID_PAYMENT_DATE, VALID_PAYMENT_STATUS);
         assertThrows(IllegalValueException.class, person::toModelType);
+
+        // Invalid tags as it breaks the maximum char constraints
+        invalidTags = new ArrayList<>(VALID_TAGS);
+        invalidTags.add(new JsonAdaptedTag("1234567890TOOLONG#123123"));
+        person =
+                new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_EDULEVEL,
+                        VALID_CURRENT_YEAR, VALID_CURRENT_GRADE, VALID_EXP_GRADE,
+                        invalidTags, VALID_PAYMENT_FEE, VALID_PAYMENT_DATE, VALID_PAYMENT_STATUS);
+        assertThrows(IllegalValueException.class, person::toModelType);
+
+        // Invalid tags as it breaks the maximum tags in set constraints
+        invalidTags = new ArrayList<>(VALID_TAGS);
+        invalidTags.add(new JsonAdaptedTag("1"));
+        invalidTags.add(new JsonAdaptedTag("2"));
+        invalidTags.add(new JsonAdaptedTag("3"));
+        invalidTags.add(new JsonAdaptedTag("4"));
+        invalidTags.add(new JsonAdaptedTag("5"));
+        invalidTags.add(new JsonAdaptedTag("6"));
+        invalidTags.add(new JsonAdaptedTag("7"));
+        invalidTags.add(new JsonAdaptedTag("8"));
+        invalidTags.add(new JsonAdaptedTag("9"));
+        person =
+                new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_EDULEVEL,
+                        VALID_CURRENT_YEAR, VALID_CURRENT_GRADE, VALID_EXP_GRADE,
+                        invalidTags, VALID_PAYMENT_FEE, VALID_PAYMENT_DATE, VALID_PAYMENT_STATUS);
+        assertThrows(IllegalValueException.class, person::toModelType);
     }
 
     @Test

--- a/src/test/java/seedu/address/testutil/TypicalPersons.java
+++ b/src/test/java/seedu/address/testutil/TypicalPersons.java
@@ -34,18 +34,18 @@ public class TypicalPersons {
     public static final Person ALICE = new PersonBuilder().withName("Alice Pauline")
             .withAddress("123, Jurong West Ave 6, #08-111").withEmail("alice@example.com")
             .withPhone("94351253").withEduLevel("Bachelor").withCurrentYear("Year 3")
-            .withCurrentGrade("D").withExpectedGrade("A").withTags("friends").build();
+            .withCurrentGrade("D").withExpectedGrade("A").withTags("CS2030C").build();
     public static final Person BENSON = new PersonBuilder().withName("Benson Meier")
             .withAddress("311, Clementi Ave 2, #02-25").withPaymentFee(500).withPaymentStatus("Paid")
             .withEmail("johnd@example.com").withPhone("98765432").withEduLevel("Bachelor").withCurrentYear("Year 4")
-            .withCurrentGrade("B-").withExpectedGrade("B").withTags("owesMoney", "friends").build();
+            .withCurrentGrade("B-").withExpectedGrade("B").withTags("GEA1000", "CS2030C").build();
     public static final Person CARL = new PersonBuilder().withName("Carl Kurz").withPhone("95352563")
             .withEmail("heinz@example.com").withAddress("wall street").withEduLevel("PhD")
             .withPaymentFee(1250).withPaymentDate("25-02-2025").withPaymentStatus("Waiting")
             .withExpectedGrade("C").build();
     public static final Person DANIEL = new PersonBuilder().withName("Daniel Meier").withPhone("87652533")
             .withEmail("cornelia@example.com").withEduLevel("Master").withAddress("10th street")
-            .withExpectedGrade("D").withTags("friends").withPaymentFee(1000)
+            .withExpectedGrade("D").withTags("CS2030C").withPaymentFee(1000)
             .withPaymentDate("22-04-2025").withPaymentStatus("Paid").build();
     public static final Person ELLE = new PersonBuilder().withName("Elle Meyer").withPhone("9482224")
             .withEmail("werner@example.com").withEduLevel("Bachelor").withAddress("michegan ave")


### PR DESCRIPTION
Closes #122

- [X] Updated Minimum & Default window size to 1080 by 600 pixels.
- [X] Updated outdated Tag (i.e. `owesMoney`) used in command usage message and testcases.
- [X] Limited the unique number of tags in each person to 8. (Both `Add` and `Edit` command)
- [X] Limited the number of characters in each Tag (excluding Hexadecimal Color Code) to 10.
- [x] Updated `UserGuide.md` to include these constraints.
- [x] Updated `benny.md`.

Useful Commands for testing:
1. `Add` command limit:
```
add n/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA p/91234567 e/BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB@example.com a/CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC l/Diploma cy/DDDDDDDDDDDDDDDDDDDDDDDDDDDDDD cg/A t/0000000000 t/0000000002 t/0000000003 t/0000000004 t/0000000005 t/0000000006 t/0000000007 t/0000000008#ABCDEF
```
2. `Edit` command limit:
```
edit 1 t/0000000000 t/0000000002 t/0000000003 t/0000000004 t/0000000005 t/0000000006 t/0000000007 t/0000000008#ABCDEF
```