### PR TITLE
Fix issue where certain commands allowed prefixes with blank fields.

### DIFF
--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -50,7 +50,22 @@ public class AddCommandParser implements Parser<AddCommand> {
 
         argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS,
                 PREFIX_EDULEVEL, PREFIX_CURRENT_YEAR, PREFIX_CURRENT_GRADE, PREFIX_EXP_GRADE);
-
+        if (argMultimap.isEmptyField(PREFIX_EDULEVEL)) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, PREFIX_EDULEVEL + " cannot be empty."));
+        }
+        if (argMultimap.isEmptyField(PREFIX_CURRENT_YEAR)) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, PREFIX_CURRENT_YEAR + " cannot be empty."));
+        }
+        if (argMultimap.isEmptyField(PREFIX_CURRENT_GRADE)) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, PREFIX_CURRENT_GRADE + " cannot be empty."));
+        }
+        if (argMultimap.isEmptyField(PREFIX_EXP_GRADE)) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, PREFIX_EXP_GRADE + " cannot be empty."));
+        }
         Name name = ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get());
         Phone phone = ParserUtil.parsePhone(argMultimap.getValue(PREFIX_PHONE).get());
         Email email = ParserUtil.parseEmail(argMultimap.getValue(PREFIX_EMAIL).get());

--- a/src/main/java/seedu/address/logic/parser/ArgumentMultimap.java
+++ b/src/main/java/seedu/address/logic/parser/ArgumentMultimap.java
@@ -36,6 +36,22 @@ public class ArgumentMultimap {
     }
 
     /**
+     * Check if {@code prefix} is present
+     */
+    public boolean isPrefixPresent(Prefix prefix) {
+        return argMultimap.containsKey(prefix);
+    }
+
+    /**
+     * Check if {@code prefix} is present but field is empty string.
+     */
+    public boolean isEmptyField(Prefix prefix) {
+        return isPrefixPresent(prefix) && getAllValues(prefix)
+                .stream()
+                .anyMatch(s -> s.isEmpty());
+    }
+
+    /**
      * Returns the last value of {@code prefix}.
      */
     public Optional<String> getValue(Prefix prefix) {

--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -54,7 +54,14 @@ public class EditCommandParser implements Parser<EditCommand> {
                 PREFIX_EDULEVEL, PREFIX_CURRENT_YEAR, PREFIX_CURRENT_GRADE, PREFIX_EXP_GRADE);
 
         EditPersonDescriptor editPersonDescriptor = new EditPersonDescriptor();
-
+        if (argMultimap.isEmptyField(PREFIX_TAG_APPEND)) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, PREFIX_TAG_APPEND + " cannot be empty."));
+        }
+        if (argMultimap.isEmptyField(PREFIX_TAG_REMOVE)) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, PREFIX_TAG_REMOVE + " cannot be empty."));
+        }
         if (argMultimap.getValue(PREFIX_NAME).isPresent()) {
             editPersonDescriptor.setName(ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get()));
         }

--- a/src/main/java/seedu/address/logic/parser/FilterCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FilterCommandParser.java
@@ -39,6 +39,10 @@ public class FilterCommandParser implements Parser<FilterCommand> {
         argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_EDULEVEL, PREFIX_CURRENT_GRADE, PREFIX_EXP_GRADE);
 
         FilterDescriptor filterDescriptor = new FilterDescriptor();
+        if (argMultimap.isEmptyField(PREFIX_TAG)) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, PREFIX_TAG + " cannot be empty."));
+        }
 
         if (argMultimap.getValue(PREFIX_EDULEVEL).isPresent()) {
             filterDescriptor.setEduLevel(ParserUtil.parseEduLevel(argMultimap.getValue(PREFIX_EDULEVEL).get()));

--- a/src/main/java/seedu/address/logic/parser/UntagCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/UntagCommandParser.java
@@ -29,6 +29,10 @@ public class UntagCommandParser implements Parser<UntagCommand> {
         if (!argMultimap.getPreamble().isEmpty() || !argMultimap.getValue(PREFIX_TAG).isPresent()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, UntagCommand.MESSAGE_USAGE));
         }
+        if (argMultimap.isEmptyField(PREFIX_TAG)) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, PREFIX_TAG + " cannot be empty."));
+        }
 
         Set<Tag> tagsToRemove = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
 

--- a/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
@@ -231,15 +231,26 @@ public class AddCommandParserTest {
                 + INVALID_TAG_DESC + VALID_TAG_FRIEND + " cg/" + VALID_GRADE_BOB + " eg/" + VALID_EXP_GRADE_BOB,
                 Tag.MESSAGE_CONSTRAINTS);
 
-        // invalid grade
+        // invalid current grade
         assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB
                 + EDULEVEL_DESC_BOB + TAG_DESC_HUSBAND + TAG_DESC_FRIEND + INVALID_GRADE_DESC
                         + " eg/" + VALID_EXP_GRADE_BOB,
                 CurrentGrade.MESSAGE_CONSTRAINTS);
 
+        // blank current grade
+        assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB
+                        + EDULEVEL_DESC_BOB + TAG_DESC_HUSBAND + TAG_DESC_FRIEND
+                        + " " + PREFIX_CURRENT_GRADE,
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, PREFIX_CURRENT_GRADE + " cannot be empty."));
+
         // invalid expected grade
         assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB
                 + INVALID_EXP_GRADE_DESC + TAG_DESC_HUSBAND + TAG_DESC_FRIEND, ExpectedGrade.MESSAGE_CONSTRAINTS);
+
+        // invalid expected grade
+        assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB
+                + " " + PREFIX_EXP_GRADE + TAG_DESC_HUSBAND + TAG_DESC_FRIEND,
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, PREFIX_EXP_GRADE + " cannot be empty."));
 
         // two invalid values, only first invalid value reported
         assertParseFailure(parser, INVALID_NAME_DESC + PHONE_DESC_BOB + EMAIL_DESC_BOB + INVALID_ADDRESS_DESC

--- a/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
@@ -116,9 +116,9 @@ public class EditCommandParserTest {
         assertParseFailure(parser, "1" + TAG_DESC_FRIEND + TAG_DESC_HUSBAND + TAG_EMPTY, Tag.MESSAGE_CONSTRAINTS);
         assertParseFailure(parser, "1" + TAG_DESC_FRIEND + TAG_EMPTY + TAG_DESC_HUSBAND, Tag.MESSAGE_CONSTRAINTS);
         assertParseFailure(parser, "1" + TAG_EMPTY + TAG_DESC_FRIEND + TAG_DESC_HUSBAND, Tag.MESSAGE_CONSTRAINTS);
-        assertParseFailure(parser, "1" + "t+/",
+        assertParseFailure(parser, "1" + " t+/",
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, PREFIX_TAG_APPEND + " cannot be empty."));
-        assertParseFailure(parser, "1" + "t-/",
+        assertParseFailure(parser, "1" + " t-/",
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, PREFIX_TAG_REMOVE + " cannot be empty."));
 
         // multiple invalid values, but only the first invalid value is captured

--- a/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
@@ -38,6 +38,8 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EXP_GRADE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG_APPEND;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG_REMOVE;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
@@ -114,6 +116,10 @@ public class EditCommandParserTest {
         assertParseFailure(parser, "1" + TAG_DESC_FRIEND + TAG_DESC_HUSBAND + TAG_EMPTY, Tag.MESSAGE_CONSTRAINTS);
         assertParseFailure(parser, "1" + TAG_DESC_FRIEND + TAG_EMPTY + TAG_DESC_HUSBAND, Tag.MESSAGE_CONSTRAINTS);
         assertParseFailure(parser, "1" + TAG_EMPTY + TAG_DESC_FRIEND + TAG_DESC_HUSBAND, Tag.MESSAGE_CONSTRAINTS);
+        assertParseFailure(parser, "1" + "t+/",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, PREFIX_TAG_APPEND + " cannot be empty."));
+        assertParseFailure(parser, "1" + "t-/",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, PREFIX_TAG_REMOVE + " cannot be empty."));
 
         // multiple invalid values, but only the first invalid value is captured
         assertParseFailure(parser, "1" + INVALID_NAME_DESC + INVALID_EMAIL_DESC + VALID_ADDRESS_AMY

--- a/src/test/java/seedu/address/logic/parser/FilterCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FilterCommandParserTest.java
@@ -58,8 +58,8 @@ public class FilterCommandParserTest {
                 INVALID_EDULEVEL_DESC + INVALID_GRADE_DESC, EduLevel.MESSAGE_CONSTRAINTS);
 
         // multiple invalid values, but only the first invalid value is captured
-        assertParseFailure(parser, INVALID_EDULEVEL_DESC + INVALID_GRADE_DESC + INVALID_EXP_GRADE_DESC
-                + INVALID_TAG_DESC, EduLevel.MESSAGE_CONSTRAINTS);
+        assertParseFailure(parser,
+                " t/", String.format(MESSAGE_INVALID_COMMAND_FORMAT, "t/ cannot be empty."));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/UntagCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/UntagCommandParserTest.java
@@ -1,9 +1,9 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
-import static seedu.address.model.tag.Tag.MESSAGE_CONSTRAINTS;
 
 import java.util.Set;
 
@@ -29,7 +29,8 @@ public class UntagCommandParserTest {
 
     @Test
     public void parse_invalidTag_failure() {
-        assertParseFailure(parser, " t/ ", MESSAGE_CONSTRAINTS);
+        assertParseFailure(parser, " t/",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, PREFIX_TAG + " cannot be empty."));
     }
 
     @Test

--- a/src/test/java/seedu/address/testutil/PersonUtil.java
+++ b/src/test/java/seedu/address/testutil/PersonUtil.java
@@ -40,10 +40,18 @@ public class PersonUtil {
         sb.append(PREFIX_PHONE + person.getPhone().value + " ");
         sb.append(PREFIX_EMAIL + person.getEmail().value + " ");
         sb.append(PREFIX_ADDRESS + person.getAddress().value + " ");
-        sb.append(PREFIX_EDULEVEL).append(person.getEduLevel().value + " ");
-        sb.append(PREFIX_CURRENT_YEAR + person.getCurrentYear().value + " ");
-        sb.append(PREFIX_CURRENT_GRADE + person.getCurrentGrade().value + " ");
-        sb.append(PREFIX_EXP_GRADE + person.getExpectedGrade().value + " ");
+        if (!person.getEduLevel().value.equals("")) {
+            sb.append(PREFIX_EDULEVEL + person.getEduLevel().value + " ");
+        }
+        if (!person.getExpectedGrade().value.equals("")) {
+            sb.append(PREFIX_EXP_GRADE + person.getExpectedGrade().value + " ");
+        }
+        if (!person.getCurrentGrade().value.equals("")) {
+            sb.append(PREFIX_CURRENT_GRADE + person.getCurrentGrade().value + " ");
+        }
+        if (!person.getCurrentYear().value.equals("")) {
+            sb.append(PREFIX_CURRENT_YEAR + person.getCurrentYear().value + " ");
+        }
         person.getTags().stream().forEach(
             s -> sb.append(PREFIX_TAG + s.fullTag + " ")
         );


### PR DESCRIPTION
### Notes:

Prevent empty fields (meaning prefix provided but no input provided) for the following commands:
- Add (cg/ eg/ cy/ l/)
- Edit (t+/ t-/)
- Filter (t/)
- Untag (t/)